### PR TITLE
Prevent constructor override when constructor is final

### DIFF
--- a/src/Phake/ClassGenerator/MockClass.php
+++ b/src/Phake/ClassGenerator/MockClass.php
@@ -339,6 +339,8 @@ class {$newClassName} {$extends}
         if (!empty($constructor) && $constructor->isFinal()) {
             return true;
         }
+
+        return false;
     }
 
     private function generateSafeConstructorOverride(ReflectionClass $mockedClass)

--- a/src/Phake/ClassGenerator/MockClass.php
+++ b/src/Phake/ClassGenerator/MockClass.php
@@ -333,9 +333,19 @@ class {$newClassName} {$extends}
         }
     }
 
+    private function isConstructorDefinedAndFinal(ReflectionClass $mockedClass)
+    {
+        $constructor = $mockedClass->getConstructor();
+        if (!empty($constructor) && $constructor->isFinal()) {
+            return true;
+        }
+    }
+
     private function generateSafeConstructorOverride(ReflectionClass $mockedClass)
     {
-        if (!$this->isConstructorDefinedInInterface($mockedClass))
+        if (!$this->isConstructorDefinedAndFinal($mockedClass)
+            && !$this->isConstructorDefinedInInterface($mockedClass)
+        )
         {
             $constructorDef = "
 	public function __construct()

--- a/tests/Phake/ClassGenerator/MockClassTest.php
+++ b/tests/Phake/ClassGenerator/MockClassTest.php
@@ -419,6 +419,33 @@ class Phake_ClassGenerator_MockClassTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests that passing constructor arguments to the derived class will cause the original constructor to be called.
+     */
+    public function testCallingFinalOriginalConstructor()
+    {
+        $newClassName = __CLASS__ . '_TestClass26';
+        $mockedClass  = 'PhakeTest_MockedFinalConstructedClass';
+        $this->classGen->generate($newClassName, $mockedClass, $this->infoRegistry);
+
+        /** @var $callRecorder Phake_CallRecorder_Recorder */
+        $callRecorder = $this->getMock('Phake_CallRecorder_Recorder');
+        /** @var $stubMapper Phake_Stubber_StubMapper */
+        $stubMapper = $this->getMock('Phake_Stubber_StubMapper');
+        $answer     = new Phake_Stubber_Answers_ParentDelegate();
+        $mock       = $this->classGen->instantiate(
+            $newClassName,
+            $callRecorder,
+            $stubMapper,
+            $answer,
+            array('val1', 'val2', 'val3')
+        );
+
+        $this->assertEquals('val1', $mock->getProp1());
+        $this->assertEquals('val2', $mock->getProp2());
+        $this->assertEquals('val3', $mock->getProp3());
+    }
+
+    /**
      * Tests that final methods are not overridden
      */
     public function testFinalMethodsAreNotOverridden()

--- a/tests/PhakeTest/MockedFinalConstructedClass.php
+++ b/tests/PhakeTest/MockedFinalConstructedClass.php
@@ -42,6 +42,11 @@
  * @link       http://www.digitalsandwich.com/
  */
 
+/**
+ * Class PhakeTest_MockedFinalConstructedClass
+ *
+ * @author Nicolas Thal<nico.th4l@gmail.com>
+ */
 class PhakeTest_MockedFinalConstructedClass
 {
     private $prop1;

--- a/tests/PhakeTest/MockedFinalConstructedClass.php
+++ b/tests/PhakeTest/MockedFinalConstructedClass.php
@@ -1,0 +1,72 @@
+<?php
+/*
+ * Phake - Mocking Framework
+ *
+ * Copyright (c) 2010-2012, Mike Lively <m@digitalsandwich.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  *  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *  *  Neither the name of Mike Lively nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category   Testing
+ * @package    Phake
+ * @author     Mike Lively <m@digitalsandwich.com>
+ * @copyright  2010 Mike Lively <m@digitalsandwich.com>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.digitalsandwich.com/
+ */
+
+class PhakeTest_MockedFinalConstructedClass
+{
+    private $prop1;
+    private $prop2;
+    private $prop3;
+
+    public final function __construct($prop1, $prop2, $prop3)
+    {
+        $this->prop1 = $prop1;
+        $this->prop2 = $prop2;
+        $this->prop3 = $prop3;
+    }
+
+    public function getProp1()
+    {
+        return $this->prop1;
+    }
+
+    public function getProp2()
+    {
+        return $this->prop2;
+    }
+
+    public function getProp3()
+    {
+        return $this->prop3;
+    }
+}


### PR DESCRIPTION
During my test, I wanted to mock a class with a final constructor like this one https://github.com/doctrine/annotations/blob/master/lib/Doctrine/Common/Annotations/Annotation.php which has a final constructor.

I have added a test for this case.

What are your thoughts about this issue?

Regards