### PR TITLE
prevent constructor override when class extend abstract and implement interface with constructor

### DIFF
--- a/src/Phake/ClassGenerator/MockClass.php
+++ b/src/Phake/ClassGenerator/MockClass.php
@@ -316,7 +316,7 @@ class {$newClassName} {$extends}
         /* @var ReflectionClass $interface */
         foreach ($reflectionClass->getInterfaces() as $interface)
         {
-            if ($interface->getConstructor() !== null)
+            if ($interface->getConstructor() !== null || $interface->hasMethod('__construct'))
             {
                 return true;
             }

--- a/tests/Phake/ClassGenerator/MockClassTest.php
+++ b/tests/Phake/ClassGenerator/MockClassTest.php
@@ -445,6 +445,28 @@ class Phake_ClassGenerator_MockClassTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('val3', $mock->getProp3());
     }
 
+
+    /**
+     * Tests the generate method of the mock class generator.
+     */
+    public function testGenerateCreatesClassWithConstructorInInterfaceButNotInAbstractClass()
+    {
+        $newClassName = __CLASS__ . '_TestClass27';
+        $mockedClass = 'PhakeTest_ImplementConstructorInterface';
+
+        $this->assertFalse(
+            class_exists($newClassName, false),
+            'The class being tested for already exists. May have created a test reusing this class name.'
+        );
+
+        $this->classGen->generate($newClassName, $mockedClass, $this->infoRegistry);
+
+        $this->assertTrue(
+            class_exists($newClassName, false),
+            'Phake_ClassGenerator_MockClass::generate() did not create correct class'
+        );
+    }
+
     /**
      * Tests that final methods are not overridden
      */

--- a/tests/PhakeTest/AbstractImplementConstructorInterface.php
+++ b/tests/PhakeTest/AbstractImplementConstructorInterface.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * Phake - Mocking Framework
+ *
+ * Copyright (c) 2010-2012, Mike Lively <m@digitalsandwich.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  *  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *  *  Neither the name of Mike Lively nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category   Testing
+ * @package    Phake
+ * @author     Mike Lively <m@digitalsandwich.com>
+ * @copyright  2010 Mike Lively <m@digitalsandwich.com>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.digitalsandwich.com/
+ */
+
+
+abstract class PhakeTest_AbstractImplementConstructorInterface implements PhakeTest_ConstructorInterface
+{
+}

--- a/tests/PhakeTest/AbstractImplementConstructorInterface.php
+++ b/tests/PhakeTest/AbstractImplementConstructorInterface.php
@@ -45,4 +45,8 @@
 
 abstract class PhakeTest_AbstractImplementConstructorInterface implements PhakeTest_ConstructorInterface
 {
+    public function __construct(PhakeTest_A $a)
+    {
+        // TODO: Implement __construct() method.
+    }
 }

--- a/tests/PhakeTest/ImplementConstructorInterface.php
+++ b/tests/PhakeTest/ImplementConstructorInterface.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ * Phake - Mocking Framework
+ *
+ * Copyright (c) 2010-2012, Mike Lively <m@digitalsandwich.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  *  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *  *  Neither the name of Mike Lively nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category   Testing
+ * @package    Phake
+ * @author     Mike Lively <m@digitalsandwich.com>
+ * @copyright  2010 Mike Lively <m@digitalsandwich.com>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.digitalsandwich.com/
+ */
+
+
+class PhakeTest_ImplementConstructorInterface extends PhakeTest_AbstractImplementConstructorInterface
+{
+    public function __construct(PhakeTest_A $a)
+    {
+        // TODO: Implement __construct() method.
+    }
+
+}

--- a/tests/PhakeTest/ImplementConstructorInterface.php
+++ b/tests/PhakeTest/ImplementConstructorInterface.php
@@ -45,9 +45,4 @@
 
 class PhakeTest_ImplementConstructorInterface extends PhakeTest_AbstractImplementConstructorInterface
 {
-    public function __construct(PhakeTest_A $a)
-    {
-        // TODO: Implement __construct() method.
-    }
-
 }


### PR DESCRIPTION
Hi,

I also had this issue with a class which extend an abstract class which implements an interface and the constructor is defined in the interface and implemented only in the base class.

I noticed that getConstructor() method always returns null on the interfaces, therefore I have added a little test.

What are your thoughts about this issue?

Regards,