### PR TITLE
Replace thenGetReturnByLambda with thenReturnCallback and deprecate

### DIFF
--- a/docs/answers.rst
+++ b/docs/answers.rst
@@ -127,7 +127,7 @@ your unit tests there may occasionally be times when you need more control over 
 methods. When this is the case, you can use a callback answer. These do generally increase the complexity of tests and
 you really should only use them if you won't know what you need to return until call time.
 
-You can specify a callback answer using the thenGetReturnByLambda method. This argument takes a callback or a closure.
+You can specify a callback answer using the thenReturnCallback method. This argument takes a callback or a closure.
 The callback will be passed the same arguments as were passed to the method being stubbed. This allows you to use them
 to help determine the answer.
 
@@ -139,7 +139,7 @@ to help determine the answer.
         public function testCallback()
         {
             $mock = Phake::mock('MyClass');
-            Phake::when($mock)->foo()->thenGetReturnByLambda(function ($val) { return $val * 2; });
+            Phake::when($mock)->foo()->thenReturnCallback(function ($val) { return $val * 2; });
 
             $this->assertEquals(42, $mock->foo(21));
         }

--- a/src/Phake/Proxies/AnswerBinderProxy.php
+++ b/src/Phake/Proxies/AnswerBinderProxy.php
@@ -82,11 +82,8 @@ class Phake_Proxies_AnswerBinderProxy
      */
     public function thenGetReturnByLambda($value)
     {
-        if (!is_callable($value)) {
-            throw new InvalidArgumentException("Given lambda is not callable");
-        }
-
-        return $this->binder->bindAnswer(new Phake_Stubber_Answers_LambdaAnswer($value));
+        trigger_error('Use thenReturnCallback instead.', E_USER_DEPRECATED);
+        return $this->thenReturnCallback($value);
     }
 
     /**
@@ -99,7 +96,11 @@ class Phake_Proxies_AnswerBinderProxy
      */
     public function thenReturnCallback($value)
     {
-        return $this->thenGetReturnByLambda($value);
+        if (!is_callable($value)) {
+            throw new InvalidArgumentException("Given lambda is not callable");
+        }
+
+        return $this->binder->bindAnswer(new Phake_Stubber_Answers_LambdaAnswer($value));
     }
 
     /**

--- a/src/Phake/Proxies/AnswerBinderProxy.php
+++ b/src/Phake/Proxies/AnswerBinderProxy.php
@@ -76,6 +76,7 @@ class Phake_Proxies_AnswerBinderProxy
      *
      * @param callback $value
      *
+     * @deprecated Use thenReturnCallback instead.
      * @throws InvalidArgumentException
      * @return Phake_Stubber_IAnswerContainer
      */
@@ -86,6 +87,19 @@ class Phake_Proxies_AnswerBinderProxy
         }
 
         return $this->binder->bindAnswer(new Phake_Stubber_Answers_LambdaAnswer($value));
+    }
+
+    /**
+     * Binds a callback answer to the method.
+     *
+     * @param callback $value
+     *
+     * @throws InvalidArgumentException
+     * @return Phake_Stubber_IAnswerContainer
+     */
+    public function thenReturnCallback($value)
+    {
+        return $this->thenGetReturnByLambda($value);
     }
 
     /**

--- a/tests/Phake/Matchers/ReferenceSetterTest.php
+++ b/tests/Phake/Matchers/ReferenceSetterTest.php
@@ -78,7 +78,7 @@ class Phake_Matchers_ReferenceSetterTest extends PHPUnit_Framework_TestCase
     {
         $matcher = Phake::mock('Phake_Matchers_IChainableArgumentMatcher');
         $check = '';
-        Phake::when($matcher)->doArgumentsMatch->thenGetReturnByLambda(function ($arg) use (&$check) {
+        Phake::when($matcher)->doArgumentsMatch->thenReturnCallback(function ($arg) use (&$check) {
                 $check = $arg[0];
                 return true;
             });

--- a/tests/Phake/Proxies/AnswerBinderProxyTest.php
+++ b/tests/Phake/Proxies/AnswerBinderProxyTest.php
@@ -95,7 +95,7 @@ class Phake_Proxies_AnswerBinderProxyTest extends PHPUnit_Framework_TestCase
      *
      * It should result in the binder being called with a lambda answer
      */
-    public function testThenGetReturnByLambda()
+    public function testThenReturnCallback()
     {
         $func = create_function('$arg1', 'return $arg1;');
 
@@ -109,18 +109,18 @@ class Phake_Proxies_AnswerBinderProxyTest extends PHPUnit_Framework_TestCase
             )
             ->will($this->returnValue($this->binder));
 
-        $this->assertSame($this->binder, $this->proxy->thenGetReturnByLambda($func));
+        $this->assertSame($this->binder, $this->proxy->thenReturnCallback($func));
     }
 
     /**
      * Tests that thenGetReturnByLambda throws an exception if the given lambda is not callable
      */
-    public function testThenGetReturnByLambdaThrowsExceptionForUncallableLambda()
+    public function testThenReturnCallbackThrowsExceptionForUncallableLambda()
     {
         $this->setExpectedException('InvalidArgumentException');
 
         $func = 'some_unknown_function';
-        $this->proxy->thenGetReturnByLambda($func);
+        $this->proxy->thenReturnCallback($func);
     }
 
     /**

--- a/tests/PhakeTest.php
+++ b/tests/PhakeTest.php
@@ -1606,4 +1606,15 @@ class PhakeTest extends PHPUnit_Framework_TestCase
         Phake::verify($mock)->foo('b');
         Phake::verifyNoOtherInteractions($mock);
     }
+
+    public function testThenReturnCallback()
+    {
+        $mock = Phake::mock('PhakeTest_MockedClass');
+
+        Phake::when($mock)->foo->thenReturnCallback(function () {
+            return true;
+        });
+
+        $this->assertTrue($mock->foo());
+    }
 }


### PR DESCRIPTION
Left the other method in so as not to break backwards compatibility.