### PR TITLE
Clean up method that creates mocks.

### DIFF
--- a/tests/Phake/ClassGenerator/MockClassTest.php
+++ b/tests/Phake/ClassGenerator/MockClassTest.php
@@ -44,8 +44,6 @@
 
 /**
  * Description of MockClass
- *
- * @todo Fix the instiate calls that are doing exactly the same basic thing...
  */
 class Phake_ClassGenerator_MockClassTest extends PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Split in to two methods. Use correct way to create new object without constructor. Use less reflection.

We encountered a bug where PHP 5.6.10 would crash when using the @ operator on the unserialize() function. Removing the @ operator fixed the issue, so I created a PR in which the @ operator is no longer required. Gives also clearer code, and instanciates far fewer objects. E.g. in the master branch the $mockObject would be instanciated and overwritten a few times. 