### PR TITLE
Support mocking classes with variadic methods

### DIFF
--- a/src/Phake/ClassGenerator/MockClass.php
+++ b/src/Phake/ClassGenerator/MockClass.php
@@ -501,13 +501,17 @@ class {$newClassName} {$extends}
             }
         }
 
-        if ($parameter->isDefaultValueAvailable()) {
-            $default = ' = ' . var_export($parameter->getDefaultValue(), true);
-        } elseif ($parameter->isOptional()) {
-            $default = ' = null';
+        $isVariadic = method_exists($parameter, 'isVariadic') && $parameter->isVariadic();
+
+        if (!$isVariadic) {
+            if ($parameter->isDefaultValueAvailable()) {
+                $default = ' = ' . var_export($parameter->getDefaultValue(), true);
+            } elseif ($parameter->isOptional()) {
+                $default = ' = null';
+            }
         }
 
-        return $type . ($parameter->isPassedByReference() ? '&' : '') . '$' . $parameter->getName() . $default;
+        return $type . ($parameter->isPassedByReference() ? '&' : '') . ($isVariadic ? '...' : '') . '$' . $parameter->getName() . $default;
     }
 
     /**


### PR DESCRIPTION
Mocking a class which has a variadic method causes the following strict PHP error:

    Declaration of SOMECLASS_PHAKEabcdef123456::someMethod() should be compatible with SomeClass::someMethod(...$args)

Luckily, `ReflectionParameter` has been extended with an `isVariadic` method: http://php.net/manual/en/reflectionparameter.isvariadic.php

Variadic parameters can have typehints, may be passed by reference, but cannot have a default value.