### PR TITLE
Adding support for scalar type hints and return types.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,8 @@ matrix:
       env: PHPUNIT_VERSION=6.0.x-dev
     - php: 5.6
       env: PHPUNIT_VERSION=6.0.x-dev
+    - php: hhvm
+      env: PHPUNIT_VERSION=6.0.x-dev
 
 install:
   - composer require --dev phpunit/phpunit:${PHPUNIT_VERSION}

--- a/src/Phake.php
+++ b/src/Phake.php
@@ -85,7 +85,7 @@ class Phake
     public static function mock($className, Phake_Stubber_IAnswerContainer $defaultAnswer = null)
     {
         if ($defaultAnswer === null) {
-            $answer = new Phake_Stubber_Answers_StaticAnswer(null);
+            $answer = new Phake_Stubber_Answers_SmartDefaultAnswer();
         } else {
             $answer = $defaultAnswer->getAnswer();
         }

--- a/src/Phake/ClassGenerator/MockClass.php
+++ b/src/Phake/ClassGenerator/MockClass.php
@@ -405,10 +405,16 @@ class {$newClassName} {$extends}
             $context = '$this';
         }
 
+        $returnType = '';
+        if (method_exists($method, 'hasReturnType') && $method->hasReturnType())
+        {
+            $returnType = ' : ' . $method->getReturnType();
+        }
+
         $docComment = $method->getDocComment() ?: '';
         $methodDef = "
 	{$docComment}
-	{$modifiers} function {$reference}{$method->getName()}({$this->generateMethodParameters($method)})
+	{$modifiers} function {$reference}{$method->getName()}({$this->generateMethodParameters($method)}){$returnType}
 	{
 		\$__PHAKE_args = array();
 		{$this->copyMethodParameters($method)}
@@ -504,6 +510,9 @@ class {$newClassName} {$extends}
                 $type = 'callable ';
             } elseif ($parameter->getClass() !== null) {
                 $type = $parameter->getClass()->getName() . ' ';
+            } elseif (method_exists($parameter, 'hasType') && $parameter->hasType())
+            {
+                $type = $parameter->getType() . ' ';
             }
         }
         catch (ReflectionException $e)

--- a/src/Phake/Stubber/Answers/SmartDefaultAnswer.php
+++ b/src/Phake/Stubber/Answers/SmartDefaultAnswer.php
@@ -1,0 +1,102 @@
+<?php
+/*
+ * Phake - Mocking Framework
+ *
+ * Copyright (c) 2010-2012, Mike Lively <m@digitalsandwich.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  *  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *  *  Neither the name of Mike Lively nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category   Testing
+ * @package    Phake
+ * @author     Mike Lively <m@digitalsandwich.com>
+ * @copyright  2010 Mike Lively <m@digitalsandwich.com>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.digitalsandwich.com/
+ */
+
+/**
+ * Returns the proper default value for a method based on the return type.
+ *
+ * @author Mike Lively <m@digitalsandwich.com>
+ */
+class Phake_Stubber_Answers_SmartDefaultAnswer implements Phake_Stubber_IAnswer
+{
+    public function processAnswer($answer)
+    {
+
+    }
+
+    public function getAnswerCallback($context, $method)
+    {
+        $class = new ReflectionClass($context);
+        $method = $class->getMethod($method);
+
+        $defaultAnswer = null;
+
+        if (method_exists($method, 'hasReturnType') && $method->hasReturnType())
+        {
+            switch ((string)$method->getReturnType())
+            {
+                case 'int':
+                    $defaultAnswer = 0;
+                    break;
+                case 'float':
+                    $defaultAnswer = 0.0;
+                    break;
+                case 'string':
+                    $defaultAnswer = "";
+                    break;
+                case 'bool':
+                    $defaultAnswer = false;
+                    break;
+                case 'array':
+                    $defaultAnswer = array();
+                    break;
+                case 'callable':
+                    $defaultAnswer = function () {};
+                    break;
+                default:
+                    if (class_exists((string)$method->getReturnType()))
+                    {
+                        $defaultAnswer = Phake::mock((string)$method->getReturnType());
+                    }
+                    break;
+            }
+        }
+
+        return function () use ($defaultAnswer)
+        {
+            return $defaultAnswer;
+        };
+    }
+}
+
+

--- a/tests/Phake/ClassGenerator/MockClassTest.php
+++ b/tests/Phake/ClassGenerator/MockClassTest.php
@@ -639,5 +639,59 @@ class Phake_ClassGenerator_MockClassTest extends PHPUnit_Framework_TestCase
 
         Phake::verify($mock)->variadicMethod(1, 2, 3, 4, 5, 6);
     }
+
+    public function testStubbingScalarReturnHints()
+    {
+        if (version_compare(phpversion(), '7.0.0RC1') < 0)
+        {
+            $this->markTestSkipped('Scalar type hints are not supported in PHP versions prior to 7.0');
+        }
+
+        $mock = Phake::mock('PhakeTest_ScalarTypes');
+
+        Phake::when($mock)->scalarHints->thenReturn(2);
+
+        $this->assertEquals(2, $mock->scalarHints(1, 1));
+    }
+
+    public function testStubbingScalarReturnsWrongType()
+    {
+        if (version_compare(phpversion(), '7.0.0RC1') < 0)
+        {
+            $this->markTestSkipped('Scalar type hints are not supported in PHP versions prior to 7.0');
+        }
+
+        $mock = Phake::mock('PhakeTest_ScalarTypes');
+
+        Phake::when($mock)->scalarHints->thenReturn(array());
+
+        try
+        {
+            $this->assertEquals(array(), $mock->scalarHints(1, 1));
+        }
+        catch (TypeError $e)
+        {
+            return;
+        }
+        catch (Throwable $e)
+        {
+            $this->fail("Expected A Type Error, instead got " . get_class($e) . " {$e}");
+        }
+        $this->fail("Expected A Type Error, no error received");
+    }
+
+    public function testDefaultStubChanged()
+    {
+        if (version_compare(phpversion(), '7.0.0RC1') < 0)
+        {
+            $this->markTestSkipped('Scalar type hints are not supported in PHP versions prior to 7.0');
+        }
+
+        $mock = Phake::mock('PhakeTest_ScalarTypes');
+
+        $mock->scalarHints(1, 1);
+
+        Phake::verify($mock)->scalarHints(1, 1);
+    }
 }
 

--- a/tests/Phake/Stubber/Answers/SmartDefaultAnswerTest.php
+++ b/tests/Phake/Stubber/Answers/SmartDefaultAnswerTest.php
@@ -1,0 +1,107 @@
+<?php
+/*
+ * Phake - Mocking Framework
+ *
+ * Copyright (c) 2010-2012, Mike Lively <m@digitalsandwich.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  *  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *  *  Neither the name of Mike Lively nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category   Testing
+ * @package    Phake
+ * @author     Mike Lively <m@digitalsandwich.com>
+ * @copyright  2010 Mike Lively <m@digitalsandwich.com>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.digitalsandwich.com/
+ */
+
+/**
+ * Tests the functionality of the parent delegate
+ */
+class Phake_Stubber_Answers_SmartDefaultAnswerTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Phake_Stubber_Answers_SmartDefaultAnswer
+     */
+    private $answer;
+
+    /**
+     * Sets up the test fixture
+     */
+    public function setUp()
+    {
+        if (version_compare(phpversion(), '7.0.0RC1') < 0)
+        {
+            $this->markTestSkipped('Scalar type hints are not supported in PHP versions prior to 7.0');
+        }
+        $this->answer = new Phake_Stubber_Answers_SmartDefaultAnswer();
+    }
+
+    public static function typeReturnMap()
+    {
+        return array(
+            'int' => array('intReturn', 0),
+            'float' => array('floatReturn', 0.0),
+            'string' => array('stringReturn', ''),
+            'boolean' => array('boolReturn', false),
+            'array' => array('arrayReturn', array()),
+        );
+    }
+
+    /**
+     * @dataProvider typeReturnMap
+     */
+    public function testSimpleReturn($method, $expectedValue)
+    {
+        $context = new PhakeTest_ScalarTypes();
+        $cb = $this->answer->getAnswerCallback($context, $method);
+
+        $this->assertSame($expectedValue, $cb());
+    }
+
+    public function testCallableReturn()
+    {
+        $context = new PhakeTest_ScalarTypes();
+        $cb = $this->answer->getAnswerCallback($context, 'callableReturn');
+
+        $this->assertEquals(function () {}, $cb());
+    }
+
+    public function testObjectReturn()
+    {
+        $context = new PhakeTest_ScalarTypes();
+        $cb = $this->answer->getAnswerCallback($context, 'objectReturn');
+
+        $this->assertInstanceOf('PhakeTest_A', $cb());
+        $this->assertInstanceOf('Phake_IMock', $cb());
+    }
+}
+
+

--- a/tests/PhakeTest/ScalarTypes.php
+++ b/tests/PhakeTest/ScalarTypes.php
@@ -1,0 +1,79 @@
+<?php
+/*
+ * Phake - Mocking Framework
+ *
+ * Copyright (c) 2010-2012, Mike Lively <m@digitalsandwich.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  *  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *  *  Neither the name of Mike Lively nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category   Testing
+ * @package    Phake
+ * @author     Mike Lively <m@digitalsandwich.com>
+ * @copyright  2010 Mike Lively <m@digitalsandwich.com>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.digitalsandwich.com/
+ */
+
+
+class PhakeTest_ScalarTypes
+{
+    public function scalarHints(int $a, int $b) : int {
+        return $a + $b;
+    }
+
+    public function objectReturn() : PhakeTest_A {
+
+    }
+
+    public function intReturn() : int {
+
+    }
+
+    public function floatReturn() : float {
+
+    }
+
+    public function stringReturn() : string {
+
+    }
+
+    public function boolReturn() : bool {
+
+    }
+
+    public function arrayReturn() : array {
+
+    }
+
+    public function callableReturn() : callable {
+
+    }
+}


### PR DESCRIPTION
Return types are particularly tricky as now PHP does not allow returning null for hinted return types. This results in a behavioral change for Phake. Now, by default, the default value for each given return type will be the default answer. The defaults are achieved by essentially the "empty" value for each built-in type: 0, 0.0, '', false, array(). A hoop function is the default value for a callable, and if the return type is another class, a mock of that class will be returned.