### PR TITLE
Allow mocking multiple interfaces at once.

### DIFF
--- a/docs/mocks.rst
+++ b/docs/mocks.rst
@@ -16,6 +16,20 @@ can be overridden on a per method and even per parameter basis. This will be cov
 The mock  will also record all calls made to this class so that you can later verify that specific methods were called
 with the proper parameters. This will be covered in depth in :ref:`method-verification-section`.
 
+In addition to classes you can also mock interfaces directly. This is done in much the same way as a class name, you
+simply pass the interface name as the first parameter to ``Phake::mock()``.
+
+.. code-block:: php
+
+    $mock = Phake::mock('InterfaceToMock');
+
+You can also pass an array of interface names to ``Phake::mock()`` that also contains up to 1 class name. This allows
+for easier mocking of a dependency that is required to implement multiple interfaces.
+
+.. code-block:: php
+
+    $mock = Phake::mock(array('Interface1', 'Interface2'));
+
 Partial Mocks
 -------------
 

--- a/tests/Phake/ClassGenerator/MockClassTest.php
+++ b/tests/Phake/ClassGenerator/MockClassTest.php
@@ -171,6 +171,62 @@ class Phake_ClassGenerator_MockClassTest extends PHPUnit_Framework_TestCase
         $mock->fooWithArgument('bar');
     }
 
+    public function testGeneratingClassFromMultipleInterfaces()
+    {
+        $newClassName = __CLASS__ . '_testClass28';
+        $mockedClass = array('PhakeTest_MockedInterface', 'PhakeTest_ConstructorInterface');
+
+        $this->classGen->generate($newClassName, $mockedClass, $this->infoRegistry);
+
+        $reflClass = new ReflectionClass($newClassName);
+        $this->assertTrue($reflClass->implementsInterface('PhakeTest_MockedInterface'), "Implements PhakeTest_MockedInterface");
+        $this->assertTrue($reflClass->implementsInterface('PhakeTest_ConstructorInterface'), "Implements PhakeTest_ConstructorInterface");
+    }
+
+    public function testGeneratingClassFromSimilarInterfaces()
+    {
+        $newClassName = __CLASS__ . '_testClass29';
+        $mockedClass = array('PhakeTest_MockedInterface', 'PhakeTest_MockedInterface2');
+
+        $this->classGen->generate($newClassName, $mockedClass, $this->infoRegistry);
+
+        $reflClass = new ReflectionClass($newClassName);
+        $this->assertTrue($reflClass->implementsInterface('PhakeTest_MockedInterface'), "Implements PhakeTest_MockedInterface");
+        $this->assertTrue($reflClass->implementsInterface('PhakeTest_MockedInterface2'), "Implements PhakeTest_ConstructorInterface");
+    }
+
+    public function testGeneratingClassFromDuplicateInterfaces()
+    {
+        $newClassName = __CLASS__ . '_testClass30';
+        $mockedClass = array('PhakeTest_MockedInterface', 'PhakeTest_MockedInterface');
+
+        $this->classGen->generate($newClassName, $mockedClass, $this->infoRegistry);
+
+        $reflClass = new ReflectionClass($newClassName);
+        $this->assertTrue($reflClass->implementsInterface('PhakeTest_MockedInterface'), "Implements PhakeTest_MockedInterface");
+    }
+
+    public function testGeneratingClassFromInheritedInterfaces()
+    {
+        $newClassName = __CLASS__ . '_testClass31';
+        $mockedClass = array('PhakeTest_MockedInterface', 'PhakeTest_MockedChildInterface');
+
+        $this->classGen->generate($newClassName, $mockedClass, $this->infoRegistry);
+
+        $reflClass = new ReflectionClass($newClassName);
+        $this->assertTrue($reflClass->implementsInterface('PhakeTest_MockedInterface'), "Implements PhakeTest_MockedInterface");
+        $this->assertTrue($reflClass->implementsInterface('PhakeTest_MockedChildInterface'), "Implements PhakeTest_MockedInterface");
+    }
+
+    public function testGeneratingClassFromMultipleClasses()
+    {
+        $newClassName = __CLASS__ . '_testClass32';
+        $mockedClass = array('PhakeTest_MockedClass', 'PhakeTest_MockedConstructedClass');
+
+        $this->setExpectedException('RuntimeException');
+        $this->classGen->generate($newClassName, $mockedClass, $this->infoRegistry);
+    }
+
     /**
      * Tests the instantiation functionality of the mock generator.
      */

--- a/tests/Phake/FacadeTest.php
+++ b/tests/Phake/FacadeTest.php
@@ -196,7 +196,7 @@ class Phake_FacadeTest extends PHPUnit_Framework_TestCase
     {
         $mockGenerator->expects($this->once())
             ->method('generate')
-            ->with($this->matchesRegularExpression('#^[A-Za-z0-9_]+$#'), $this->equalTo($mockedClass), $this->equalTo($this->infoRegistry));
+            ->with($this->matchesRegularExpression('#^[A-Za-z0-9_]+$#'), $this->equalTo((array)$mockedClass), $this->equalTo($this->infoRegistry));
     }
 
     /**

--- a/tests/PhakeTest.php
+++ b/tests/PhakeTest.php
@@ -1651,4 +1651,23 @@ class PhakeTest extends PHPUnit_Framework_TestCase
 
         $this->assertTrue($mock->foo());
     }
+
+    public function testMockingMultipleInterfaces()
+    {
+        $mock = Phake::mock(array('PhakeTest_MockedInterface', 'PhakeTest_MockedClass'));
+        $this->assertInstanceOf('PhakeTest_MockedInterface', $mock);
+        $this->assertInstanceOf('PhakeTest_MockedClass', $mock);
+
+        Phake::when($mock)->foo->thenReturn('bar');
+        Phake::when($mock)->reference->thenReturn('foo');
+        Phake::when($mock)->fooWithArgument->thenReturn(42);
+
+        $this->assertEquals('bar', $mock->foo());
+        $this->assertEquals('foo', $mock->reference($test));
+        $this->assertEquals(42, $mock->fooWithArgument('blah'));
+
+        Phake::verify($mock)->foo();
+        Phake::verify($mock)->reference(null);
+        Phake::verify($mock)->fooWithArgument('blah');
+    }
 }

--- a/tests/PhakeTest/MockedChildInterface.php
+++ b/tests/PhakeTest/MockedChildInterface.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * Phake - Mocking Framework
+ *
+ * Copyright (c) 2010-2012, Mike Lively <m@digitalsandwich.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  *  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *  *  Neither the name of Mike Lively nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category   Testing
+ * @package    Phake
+ * @author     Mike Lively <m@digitalsandwich.com>
+ * @copyright  2010 Mike Lively <m@digitalsandwich.com>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.digitalsandwich.com/
+ */
+
+interface PhakeTest_MockedChildInterface extends PhakeTest_MockedInterface
+{
+
+}
+
+

--- a/tests/PhakeTest/MockedInterface2.php
+++ b/tests/PhakeTest/MockedInterface2.php
@@ -1,0 +1,66 @@
+<?php
+/*
+ * Phake - Mocking Framework
+ *
+ * Copyright (c) 2010-2012, Mike Lively <m@digitalsandwich.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  *  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *  *  Neither the name of Mike Lively nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category   Testing
+ * @package    Phake
+ * @author     Mike Lively <m@digitalsandwich.com>
+ * @copyright  2010 Mike Lively <m@digitalsandwich.com>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.digitalsandwich.com/
+ */
+
+interface PhakeTest_MockedInterface2
+{
+    public function foo();
+
+    public function hinted(PhakeTest_MockedInterface $hinted);
+
+    public function hintedNull(PhakeTest_MockedInterface $hinted = null);
+
+    public function hintedArray(array $hinted);
+
+    public function hintedArrayNull(array $hinted = null);
+
+    public function hintedArrayDefaulted(array $hinted = array(1, 2, 3));
+
+    public function reference(&$hinted);
+
+    public function referenceHinted(PhakeTest_MockedInterface &$hinted);
+
+    public function referenceDefault(&$hinted = 'blah');
+}
+
+


### PR DESCRIPTION
You can now specify an array of classes and interfaces to Phake::mock() or Phake::partialMock(). Fixes #185 