### PR TITLE
Use associative array for matching

### DIFF
--- a/src/Phake/Matchers/IMethodMatcher.php
+++ b/src/Phake/Matchers/IMethodMatcher.php
@@ -61,4 +61,12 @@ interface Phake_Matchers_IMethodMatcher
      * @return boolean
      */
     public function matches($method, array &$args);
+
+    /**
+     * Accessor for the expected method.
+     *
+     * @return string
+     */
+    public function getMethod();
+
 }

--- a/src/Phake/Matchers/MethodMatcher.php
+++ b/src/Phake/Matchers/MethodMatcher.php
@@ -134,4 +134,12 @@ class Phake_Matchers_MethodMatcher implements Phake_Matchers_IMethodMatcher
             throw new Phake_Exception_MethodMatcherException("No matchers were given to Phake::when(), but arguments were received by this method.");
         }
     }
+
+    /**
+     * @return string
+     */
+    public function getMethod()
+    {
+        return $this->expectedMethod;
+    }
 }

--- a/src/Phake/Stubber/StubMapper.php
+++ b/src/Phake/Stubber/StubMapper.php
@@ -62,7 +62,7 @@ class Phake_Stubber_StubMapper
      */
     public function mapStubToMatcher(Phake_Stubber_AnswerCollection $answer, Phake_Matchers_IMethodMatcher $matcher)
     {
-        $this->matcherStubMap[] = array($matcher, $answer);
+        $this->matcherStubMap[$matcher->getMethod()][] = array($matcher, $answer);
     }
 
     /**
@@ -75,7 +75,7 @@ class Phake_Stubber_StubMapper
      */
     public function getStubByCall($method, array &$args)
     {
-        $matcherStubMap = array_reverse($this->matcherStubMap);
+        $matcherStubMap = isset($this->matcherStubMap[$method]) ? array_reverse($this->matcherStubMap[$method]) : [];
 
         foreach ($matcherStubMap as $item) {
             list($matcher, $answer) = $item;

--- a/src/Phake/Stubber/StubMapper.php
+++ b/src/Phake/Stubber/StubMapper.php
@@ -75,7 +75,7 @@ class Phake_Stubber_StubMapper
      */
     public function getStubByCall($method, array &$args)
     {
-        $matcherStubMap = isset($this->matcherStubMap[$method]) ? array_reverse($this->matcherStubMap[$method]) : [];
+        $matcherStubMap = isset($this->matcherStubMap[$method]) ? array_reverse($this->matcherStubMap[$method]) : array();
 
         foreach ($matcherStubMap as $item) {
             list($matcher, $answer) = $item;

--- a/tests/Phake/Stubber/StubMapperTest.php
+++ b/tests/Phake/Stubber/StubMapperTest.php
@@ -75,6 +75,10 @@ class Phake_Stubber_StubMapperTest extends PHPUnit_Framework_TestCase
             ->with('foo', array('bar', 'test'))
             ->will($this->returnValue(true));
 
+        $matcher->expects($this->any())
+            ->method('getMethod')
+            ->will($this->returnValue('foo'));
+
         $this->mapper->mapStubToMatcher($stub, $matcher);
 
         $arguments = array('bar', 'test');
@@ -132,10 +136,18 @@ class Phake_Stubber_StubMapperTest extends PHPUnit_Framework_TestCase
         $also_matches->expects($this->never())
             ->method('matches');
 
+        $also_matches->expects($this->any())
+            ->method('getMethod')
+            ->will($this->returnvalue('foo'));
+
         $match_me->expects($this->any())
             ->method('matches')
             ->with('foo', array('bar', 'test'))
             ->will($this->returnValue(true));
+
+        $match_me->expects($this->any())
+            ->method('getMethod')
+            ->will($this->returnvalue('foo'));
 
         $this->mapper->mapStubToMatcher($also_matches_stub, $also_matches);
         $this->mapper->mapStubToMatcher($match_me_stub, $match_me);


### PR DESCRIPTION
This change speeds up performance of matching stubs by using
an associative array for storing the matchers for a mock object.

Part of this change adds a getter method to IMethodMatcher,
which means it will force any class that implements this
interface to implement getMethod().  This makes this change a breaking
change, so it should be handled accordingly.

This change adde