### PR TITLE
update evaluate signature in Phake_PHPUnit_VerifierResultConstraint

### DIFF
--- a/src/Phake/PHPUnit/VerifierResultConstraint.php
+++ b/src/Phake/PHPUnit/VerifierResultConstraint.php
@@ -48,7 +48,7 @@
  */
 class Phake_PHPUnit_VerifierResultConstraint extends PHPUnit_Framework_Constraint
 {
-    public function evaluate($other)
+    public function evaluate($other, $description = '', $returnResult = FALSE)
     {
         if (!$other instanceof Phake_CallRecorder_VerifierResult) {
             throw new InvalidArgumentException("You must pass an instance of Phake_CallRecorder_VerifierResult");


### PR DESCRIPTION
Ran into an issue with this test: https://github.com/phergie/phergie-irc-plugin-react-url/blob/b6525364c269050e2f98d6da3394da48766d7d0d/tests/DefaultUrlHandlerTest.php#L120

```
PHPUnit 2.0.1-13-g4a4f0f5 by Sebastian Bergmann.

Configuration read from /Users/halo/PhpstormProjects/phergie-irc-plugin-react-url/phpunit.xml

The Xdebug extension is not loaded. No code coverage will be generated.

.......E...................................................

Time: 0 seconds, Memory: 6.00Mb

There was 1 error:

1) Phergie\Tests\Irc\Plugin\React\Url\DefaultUrlHandlerTest::testHandle
Declaration of Phake_PHPUnit_VerifierResultConstraint::evaluate($other) should be compatible with PHPUnit_Framework_Constraint::evaluate($other, $description = '', $returnResult = false)

/Users/halo/PhpstormProjects/phergie-irc-plugin-react-url/vendor/phake/phake/src/Phake/PHPUnit/VerifierResultConstraint.php:72
/Users/halo/PhpstormProjects/phergie-irc-plugin-react-url/vendor/phake/phake/src/Phake/Client/PHPUnit.php:69
/Users/halo/PhpstormProjects/phergie-irc-plugin-react-url/vendor/phake/phake/src/Phake/Client/PHPUnit.php:56
/Users/halo/PhpstormProjects/phergie-irc-plugin-react-url/vendor/phake/phake/src/Phake/Proxies/VerifierProxy.php:109
/Users/halo/PhpstormProjects/phergie-irc-plugin-react-url/tests/DefaultUrlHandlerTest.php:119

FAILURES!
Tests: 59, Assertions: 83, Errors: 1.
```

Google turned up this link: https://github.com/mlively/Phake/issues/44 and it's resolution: https://github.com/mlively/Phake/commit/7c8ee6461d4d2ad6b90fc76397881b3922305543

I added a similar fix and my tests are now passing. Did I stumble into a bug or am I doing something wrong?