### PR TITLE
Fix Answer Callbacks code example

### DIFF
--- a/docs/answers.rst
+++ b/docs/answers.rst
@@ -139,7 +139,7 @@ to help determine the answer.
         public function testCallback()
         {
             $mock = Phake::mock('MyClass');
-            Phake::when($mock)->foo()->thenReturnCallback(function ($val) { return $val * 2; });
+            Phake::when($mock)->foo->thenReturnCallback(function ($val) { return $val * 2; });
 
             $this->assertEquals(42, $mock->foo(21));
         }


### PR DESCRIPTION
The stubbed method doesn't take a parameter, but answer callback does, which results in the latter not being called.