### PR TITLE
Should resolve the lack of private support (essentially) in makeVisible()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,13 @@ env:
 
 
 script:
-  - ./bin/phpunit --coverage-clover=build/logs/clover.xml
+  - |
+    if [[ $TRAVIS_PHP_VERSION = "hhv"* ]]; then
+      hhvm -vEval.EnableHipHopSyntax=true ./bin/phpunit --coverage-clover=build/logs/clover.xml
+    else
+      ./bin/phpunit --coverage-clover=build/logs/clover.xml
+    fi
+  -
 
 matrix:
   allow_failures:
@@ -54,12 +60,6 @@ matrix:
 install:
   - composer require --dev phpunit/phpunit:${PHPUNIT_VERSION}
   - composer install --dev
-
-before_script:
-  - |
-    if [[ $TRAVIS_PHP_VERSION = "hhv"* ]]; then
-      echo "hhvm.vm_stack_elms=32768" >> /etc/hhvm/php.ini
-    fi
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,12 @@ install:
   - composer require --dev phpunit/phpunit:${PHPUNIT_VERSION}
   - composer install --dev
 
+before_script:
+  - |
+    if [[ $TRAVIS_PHP_VERSION = "hhv"* ]]; then
+      echo "hhvm.vm_stack_elms=32768" >> /etc/hhvm/php.ini
+    fi
+
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml

--- a/src/Phake/ClassGenerator/MockClass.php
+++ b/src/Phake/ClassGenerator/MockClass.php
@@ -479,7 +479,15 @@ class {$newClassName} {$extends}
 		\$__PHAKE_answer = \$__PHAKE_info->getHandlerChain()->invoke({$context}, '{$method->getName()}', \$__PHAKE_funcArgs, \$__PHAKE_args);
 
 	    \$__PHAKE_callback = \$__PHAKE_answer->getAnswerCallback({$context}, '{$method->getName()}');
-	    \$__PHAKE_result = call_user_func_array(\$__PHAKE_callback, \$__PHAKE_args);
+
+	    if (\$__PHAKE_callback instanceof Phake_Stubber_Answers_ParentDelegateCallback)
+	    {
+    	    \$__PHAKE_result = \$__PHAKE_callback(\$__PHAKE_args);
+	    }
+	    else
+	    {
+    	    \$__PHAKE_result = call_user_func_array(\$__PHAKE_callback, \$__PHAKE_args);
+	    }
 	    \$__PHAKE_answer->processAnswer(\$__PHAKE_result);
 	    return \$__PHAKE_result;
 	}

--- a/src/Phake/Stubber/Answers/ParentDelegate.php
+++ b/src/Phake/Stubber/Answers/ParentDelegate.php
@@ -81,7 +81,7 @@ class Phake_Stubber_Answers_ParentDelegate implements Phake_Stubber_IAnswer
 
             if (!$reflMethod->isAbstract())
             {
-                return array('parent', $method);
+                return new Phake_Stubber_Answers_ParentDelegateCallback($context, $reflMethod);
             }
         }
         catch (ReflectionException $e)

--- a/src/Phake/Stubber/Answers/ParentDelegate.php
+++ b/src/Phake/Stubber/Answers/ParentDelegate.php
@@ -81,7 +81,14 @@ class Phake_Stubber_Answers_ParentDelegate implements Phake_Stubber_IAnswer
 
             if (!$reflMethod->isAbstract())
             {
-                return new Phake_Stubber_Answers_ParentDelegateCallback($context, $reflMethod);
+                if (defined('HHVM_VERSION'))
+                {
+                    return array('parent', $method);
+                }
+                else
+                {
+                    return new Phake_Stubber_Answers_ParentDelegateCallback($context, $reflMethod);
+                }
             }
         }
         catch (ReflectionException $e)

--- a/src/Phake/Stubber/Answers/ParentDelegateCallback.php
+++ b/src/Phake/Stubber/Answers/ParentDelegateCallback.php
@@ -43,79 +43,35 @@
  */
 
 /**
- * Description of MockedClass
- *
- * @author Mike Lively <m@digitalsandwich.com>
+ * A callable class that allows for calling parent methods without losing references.
  */
-class PhakeTest_MockedClass
+class Phake_Stubber_Answers_ParentDelegateCallback
 {
-    public function foo()
-    {
-    }
-
-    public function fooWithDefault($default = null)
-    {
-    }
-
-    public function fooWithArgument($arg1)
-    {
-    }
-
-    public function fooWithReturnValue()
-    {
-        return 'blah';
-    }
-
-    public function callInnerFunc()
-    {
-        return $this->innerFunc();
-    }
-
-    protected function innerFunc()
-    {
-        return 'test';
-    }
-
-    private function privateFunc()
-    {
-        return 'blah';
-    }
-
-    private static function privateStaticFunc()
-    {
-        return 'blah static';
-    }
-
-    public function chainedCall()
-    {
-        return $this->callInnerFunc();
-    }
-
-    public function fooWithLotsOfParameters($parm1, $parm2, $parm3)
-    {
-
-    }
-
-    public function fooWithRefParm($parm1, &$parm2 = null)
-    {
-
-	}
-
-    public function fooWithVariableNumberOfArguments($x = null)
-    {
-        return func_get_args();
-    }
-
-    public function fooWithSetDefault($bar = 42)
-    {
-
-    }
+    private $context;
 
     /**
-     * @return void
+     * @var ReflectionMethod
      */
-    public function fooWithComment()
+    private $parentMethod;
+
+    public function __construct($context, ReflectionMethod $parentMethod)
     {
+        $this->context = $context;
+        $this->parentMethod = $parentMethod;
+    }
+
+    public function __invoke(array $arguments)
+    {
+        $this->parentMethod->setAccessible(true);
+        if ($this->parentMethod->isStatic())
+        {
+            $context = null;
+        }
+        else
+        {
+            $context = $this->context;
+        }
+        return $this->parentMethod->invokeArgs($context, $arguments);
     }
 }
 

--- a/tests/Phake/ClassGenerator/MockClassTest.php
+++ b/tests/Phake/ClassGenerator/MockClassTest.php
@@ -61,7 +61,7 @@ class Phake_ClassGenerator_MockClassTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         Phake::initAnnotations($this);
-        $this->classGen = new Phake_ClassGenerator_MockClass();
+        $this->classGen = new Phake_ClassGenerator_MockClass(new Phake_ClassGenerator_FileLoader(__DIR__ . '/../../../cache'));
     }
 
     /**
@@ -133,7 +133,7 @@ class Phake_ClassGenerator_MockClassTest extends PHPUnit_Framework_TestCase
 
         $callRecorder = $this->getMock('Phake_CallRecorder_Recorder');
         $stubMapper   = $this->getMock('Phake_Stubber_StubMapper');
-        $answer       = Phake::mock('Phake_Stubber_Answers_NoAnswer', Phake::ifUnstubbed()->thenCallParent());
+        $answer       = new Phake_Stubber_Answers_NoAnswer();
         $mock         = $this->classGen->instantiate($newClassName, $callRecorder, $stubMapper, $answer);
 
         /* @var $callRecorder Phake_CallRecorder_Recorder */
@@ -247,6 +247,7 @@ class Phake_ClassGenerator_MockClassTest extends PHPUnit_Framework_TestCase
 
     /**
      * Tests that calling a stubbed method will result in the stubbed answer being returned.
+     * @group testonly
      */
     public function testStubbedMethodsReturnStubbedAnswer()
     {

--- a/tests/Phake/ClassGenerator/MockClassTest.php
+++ b/tests/Phake/ClassGenerator/MockClassTest.php
@@ -61,7 +61,7 @@ class Phake_ClassGenerator_MockClassTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         Phake::initAnnotations($this);
-        $this->classGen = new Phake_ClassGenerator_MockClass(new Phake_ClassGenerator_FileLoader(__DIR__ . '/../../../cache'));
+        $this->classGen = new Phake_ClassGenerator_MockClass();
     }
 
     /**

--- a/tests/Phake/Proxies/VisibilityProxyTest.php
+++ b/tests/Phake/Proxies/VisibilityProxyTest.php
@@ -78,6 +78,10 @@ class Phake_Proxies_VisibilityProxyTest extends PHPUnit_Framework_TestCase
 
     public function testCallingPrivateMethod()
     {
+        if (defined('HHVM_VERSION'))
+        {
+            $this->markTestSkipped("Can't call private methods with hhvm");
+        }
         $mock = Phake::mock('PhakeTest_MockedClass');
         $proxy = new Phake_Proxies_VisibilityProxy($mock);
 
@@ -90,6 +94,10 @@ class Phake_Proxies_VisibilityProxyTest extends PHPUnit_Framework_TestCase
 
     public function testCallingPrivateMethodThatDelegatesToParent()
     {
+        if (defined('HHVM_VERSION'))
+        {
+            $this->markTestSkipped("Can't call private methods with hhvm");
+        }
         $mock = Phake::mock('PhakeTest_MockedClass');
         $proxy = new Phake_Proxies_VisibilityProxy($mock);
 

--- a/tests/Phake/Proxies/VisibilityProxyTest.php
+++ b/tests/Phake/Proxies/VisibilityProxyTest.php
@@ -76,6 +76,30 @@ class Phake_Proxies_VisibilityProxyTest extends PHPUnit_Framework_TestCase
         Phake::verify($mock)->test();
     }
 
+    public function testCallingPrivateMethod()
+    {
+        $mock = Phake::mock('PhakeTest_MockedClass');
+        $proxy = new Phake_Proxies_VisibilityProxy($mock);
+
+        Phake::when($mock)->privateFunc()->thenReturn('bar');
+
+        $this->assertEquals('bar', $proxy->privateFunc());
+
+        Phake::verify($mock)->privateFunc();
+    }
+
+    public function testCallingPrivateMethodThatDelegatesToParent()
+    {
+        $mock = Phake::mock('PhakeTest_MockedClass');
+        $proxy = new Phake_Proxies_VisibilityProxy($mock);
+
+        Phake::when($mock)->privateFunc()->thenCallParent();
+
+        $proxy->privateFunc();
+
+        Phake::verify($mock)->privateFunc();
+    }
+
     public function testCallingProtectedMethod()
     {
         $mock = Phake::mock('PhakeTest_MockedClass');

--- a/tests/Phake/Stubber/Answers/ParentDelegateTest.php
+++ b/tests/Phake/Stubber/Answers/ParentDelegateTest.php
@@ -66,9 +66,9 @@ class Phake_Stubber_Answers_ParentDelegateTest extends PHPUnit_Framework_TestCas
     public function testThatDelegateReturnsCorrectCallback()
     {
         $m = Phake::mock('PhakeTest_MockedClass');
-        $callback = $this->delegate->getAnswerCallback($m, 'foo');
+        $callback = $this->delegate->getAnswerCallback($m, 'fooWithReturnValue');
 
-        $this->assertSame(array('parent', 'foo'), $callback);
+        $this->assertEquals('blah', $callback(array()));
     }
 
     /**
@@ -115,6 +115,20 @@ class Phake_Stubber_Answers_ParentDelegateTest extends PHPUnit_Framework_TestCas
         $callback = $this->delegate->getAnswerCallback('ClassThatDoesntExist', 'methodThatDoesntExist');
 
         $this->assertEquals(array($this->delegate, 'getFallback'), $callback);
+    }
+
+    public function testCallBackCanCallPrivateInTheParent()
+    {
+        $callback = $this->delegate->getAnswerCallback(Phake::mock('PhakeTest_MockedClass'), 'privateFunc');
+
+        $this->assertEquals('blah', call_user_func($callback, array()));
+    }
+
+    public function testCallBackCanCallPrivateStaticInTheParent()
+    {
+        $callback = $this->delegate->getAnswerCallback(Phake::mock('PhakeTest_MockedClass'), 'privateStaticFunc');
+
+        $this->assertEquals('blah static', call_user_func($callback, array()));
     }
 }
 

--- a/tests/Phake/Stubber/Answers/ParentDelegateTest.php
+++ b/tests/Phake/Stubber/Answers/ParentDelegateTest.php
@@ -68,7 +68,14 @@ class Phake_Stubber_Answers_ParentDelegateTest extends PHPUnit_Framework_TestCas
         $m = Phake::mock('PhakeTest_MockedClass');
         $callback = $this->delegate->getAnswerCallback($m, 'fooWithReturnValue');
 
-        $this->assertEquals('blah', $callback(array()));
+        if (defined('HHVM_VERSION'))
+        {
+            $this->assertEquals(array('parent', 'fooWithReturnValue'), $callback);
+        }
+        else
+        {
+            $this->assertEquals('blah', $callback(array()));
+        }
     }
 
     /**
@@ -119,6 +126,11 @@ class Phake_Stubber_Answers_ParentDelegateTest extends PHPUnit_Framework_TestCas
 
     public function testCallBackCanCallPrivateInTheParent()
     {
+        if (defined('HHVM_VERSION'))
+        {
+            $this->markTestSkipped("Can't call private methods with hhvm");
+        }
+
         $callback = $this->delegate->getAnswerCallback(Phake::mock('PhakeTest_MockedClass'), 'privateFunc');
 
         $this->assertEquals('blah', call_user_func($callback, array()));
@@ -126,6 +138,11 @@ class Phake_Stubber_Answers_ParentDelegateTest extends PHPUnit_Framework_TestCas
 
     public function testCallBackCanCallPrivateStaticInTheParent()
     {
+        if (defined('HHVM_VERSION'))
+        {
+            $this->markTestSkipped("Can't call private methods with hhvm");
+        }
+
         $callback = $this->delegate->getAnswerCallback(Phake::mock('PhakeTest_MockedClass'), 'privateStaticFunc');
 
         $this->assertEquals('blah static', call_user_func($callback, array()));

--- a/tests/PhakeTest.php
+++ b/tests/PhakeTest.php
@@ -1630,6 +1630,17 @@ class PhakeTest extends PHPUnit_Framework_TestCase
         $this->assertSame('test', $returned);
     }
 
+    public function testCallingPrivateMethods()
+    {
+        $mock = Phake::mock('PhakeTest_MockedClass');
+        Phake::when($mock)->privateFunc()->thenCallParent();
+
+        $returned = Phake::makeVisible($mock)->privateFunc();
+
+        Phake::verify($mock)->privateFunc();
+        $this->assertSame('blah', $returned);
+    }
+
     public function testCallingProtectedStaticMethods()
     {
         $mock = Phake::mock('PhakeTest_StaticClass');

--- a/tests/PhakeTest.php
+++ b/tests/PhakeTest.php
@@ -1632,6 +1632,10 @@ class PhakeTest extends PHPUnit_Framework_TestCase
 
     public function testCallingPrivateMethods()
     {
+        if (defined('HHVM_VERSION'))
+        {
+            $this->markTestSkipped("Can't call private methods with hhvm");
+        }
         $mock = Phake::mock('PhakeTest_MockedClass');
         Phake::when($mock)->privateFunc()->thenCallParent();
 


### PR DESCRIPTION
Fixes #212 by revamping a little bit how the callback from thenCallParent() works. This needs some cleanup but I have other code that is focused on reworking all of the answers a bit more and the cleanup makes more sense to happen there.