### PR TITLE
Adding the ability to return the mock object back.

### DIFF
--- a/src/Phake/Proxies/AnswerBinderProxy.php
+++ b/src/Phake/Proxies/AnswerBinderProxy.php
@@ -140,4 +140,9 @@ class Phake_Proxies_AnswerBinderProxy
     {
         return $this->binder->bindAnswer(new Phake_Stubber_Answers_NoAnswer());
     }
+
+    public function thenReturnSelf()
+    {
+        return $this->binder->bindAnswer(new Phake_Stubber_Answers_SelfAnswer());
+    }
 }

--- a/src/Phake/Stubber/Answers/InvalidAnswerException.php
+++ b/src/Phake/Stubber/Answers/InvalidAnswerException.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * Phake - Mocking Framework
+ *
+ * Copyright (c) 2010-2012, Mike Lively <m@digitalsandwich.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  *  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *  *  Neither the name of Mike Lively nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category   Testing
+ * @package    Phake
+ * @author     Mike Lively <m@digitalsandwich.com>
+ * @copyright  2010 Mike Lively <m@digitalsandwich.com>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.digitalsandwich.com/
+ */
+
+/**
+ * Thrown when an invalid answer is created or used
+ */
+class Phake_Stubber_Answers_InvalidAnswerException extends LogicException
+{
+}

--- a/src/Phake/Stubber/Answers/SelfAnswer.php
+++ b/src/Phake/Stubber/Answers/SelfAnswer.php
@@ -1,0 +1,74 @@
+<?php
+/*
+ * Phake - Mocking Framework
+ *
+ * Copyright (c) 2010-2012, Mike Lively <m@digitalsandwich.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  *  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *  *  Neither the name of Mike Lively nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category   Testing
+ * @package    Phake
+ * @author     Mike Lively <m@digitalsandwich.com>
+ * @copyright  2010 Mike Lively <m@digitalsandwich.com>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.digitalsandwich.com/
+ */
+
+class Phake_Stubber_Answers_SelfAnswer implements Phake_Stubber_IAnswer
+{
+
+    /**
+     * Returns the answer that should be used when a method stubbed to this answer is called.
+     * @param mixed $context class name or object instance
+     * @param string $method
+     * @return callable
+     */
+    public function getAnswerCallback($context, $method)
+    {
+        if (!is_object($context))
+        {
+            throw new Phake_Stubber_Answers_InvalidAnswerException("Invalid context for " . __CLASS__ . ". You can only use this answer on non-static methods");
+        }
+        return function () use ($context)
+        {
+            return $context;
+        };
+    }
+
+    /**
+     * Allows for post processing an answer if necessary
+     * @param mixed $answer
+     * @return mixed
+     */
+    public function processAnswer($answer)
+    {
+    }
+}

--- a/tests/Phake/Proxies/AnswerBinderProxyTest.php
+++ b/tests/Phake/Proxies/AnswerBinderProxyTest.php
@@ -184,6 +184,17 @@ class Phake_Proxies_AnswerBinderProxyTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame($this->binder, $this->proxy->thenDoNothing());
     }
+
+    public function testThenReturnSelf()
+    {
+        $this->binder->expects($this->once())
+            ->method('bindAnswer')
+            ->with($this->isInstanceOf('Phake_Stubber_Answers_SelfAnswer')
+            )
+            ->will($this->returnValue($this->binder));
+
+        $this->assertSame($this->binder, $this->proxy->thenReturnSelf());
+    }
 }
 
 

--- a/tests/Phake/Stubber/Answers/SelfAnswerTest.php
+++ b/tests/Phake/Stubber/Answers/SelfAnswerTest.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * Phake - Mocking Framework
+ *
+ * Copyright (c) 2010-2012, Mike Lively <m@digitalsandwich.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  *  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *  *  Neither the name of Mike Lively nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category   Testing
+ * @package    Phake
+ * @author     Mike Lively <m@digitalsandwich.com>
+ * @copyright  2010 Mike Lively <m@digitalsandwich.com>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.digitalsandwich.com/
+ */
+
+class Phake_Stubber_Answers_SelfAnswerTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Phake_Stubber_Answers_SelfAnswer
+     */
+    private $answer;
+
+    /**
+     * Sets up the answer fixture
+     */
+    public function setUp()
+    {
+        $this->answer = new Phake_Stubber_Answers_SelfAnswer();
+    }
+
+    public function testAnswer()
+    {
+        $testObj = Phake::mock('PhakeTest_MockedClass');
+        $callback = $this->answer->getAnswerCallback($testObj, 'foo');
+
+        $this->assertSame($testObj, call_user_func_array($callback, array()));
+    }
+
+    /**
+     * @expectedException Phake_Stubber_Answers_InvalidAnswerException
+     */
+    public function testThrowsOnStatic()
+    {
+        $testObj = 'PhakeTest_StaticClass'; //class name indicates static method call
+        $this->answer->getAnswerCallback($testObj, 'staticMethod');
+    }
+}

--- a/tests/PhakeTest.php
+++ b/tests/PhakeTest.php
@@ -1685,4 +1685,12 @@ class PhakeTest extends PHPUnit_Framework_TestCase
         Phake::verify($mock)->reference(null);
         Phake::verify($mock)->fooWithArgument('blah');
     }
+
+    public function testReturningSelf()
+    {
+        $mock = Phake::mock('PhakeTest_MockedClass');
+        Phake::when($mock)->foo->thenReturnSelf();
+
+        $this->assertSame($mock, $mock->foo());
+    }
 }


### PR DESCRIPTION
Fixes #215 

This assists in testing fluent interfaces:

Phake::when($mock)->foo->thenReturnSelf();

$mock->foo()->foo();

Phake::mock('MyFluentApi', Phake::ifUnstubbed()->thenReturnSelf());