### PR TITLE
Added ability to mock "unsafe classes"

### DIFF
--- a/src/Phake/ClassGenerator/MockClass.php
+++ b/src/Phake/ClassGenerator/MockClass.php
@@ -49,6 +49,7 @@
  */
 class Phake_ClassGenerator_MockClass
 {
+    private static $unsafeClasses = array('Memcached');
     /**
      * @var \Phake_ClassGenerator_ILoader
      */
@@ -229,9 +230,25 @@ class {$newClassName} {$extends}
 }
 ";
 
-        $this->loader->loadClassByString($newClassName, $classDef);
+        $this->loadClass($newClassName, $mockedClassName, $classDef);
         $newClassName::$__PHAKE_staticInfo = $this->createMockInfo($mockedClassName, new Phake_CallRecorder_Recorder(), new Phake_Stubber_StubMapper(), new Phake_Stubber_Answers_NoAnswer());
         $infoRegistry->addInfo($newClassName::$__PHAKE_staticInfo);
+    }
+
+    private function loadClass($newClassName, $mockedClassName, $classDef)
+    {
+        $isUnsafe = in_array($mockedClassName, self::$unsafeClasses);
+
+        $oldErrorReporting = ini_get('error_reporting');
+        if ($isUnsafe)
+        {
+            error_reporting($oldErrorReporting & ~E_STRICT);
+        }
+        $this->loader->loadClassByString($newClassName, $classDef);
+        if ($isUnsafe)
+        {
+            error_reporting($oldErrorReporting);
+        }
     }
 
     /**

--- a/tests/Phake/BuiltInExtensionsTest.php
+++ b/tests/Phake/BuiltInExtensionsTest.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * Phake - Mocking Framework
+ *
+ * Copyright (c) 2010-2012, Mike Lively <m@digitalsandwich.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  *  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *  *  Neither the name of Mike Lively nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category   Testing
+ * @package    Phake
+ * @author     Mike Lively <m@digitalsandwich.com>
+ * @copyright  2010 Mike Lively <m@digitalsandwich.com>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.digitalsandwich.com/
+ */
+
+class Phake_BuiltinExtensionsTest extends PHPUnit_Framework_TestCase
+{
+    public function testMemcachedGet()
+    {
+        if (!extension_loaded('memcached'))
+        {
+            $this->markTestSkipped("Cannot run test without memcached");
+        }
+
+        $mock = Phake::mock('Memcached');
+
+        $this->assertInstanceOf('Memcached', $mock);
+    }
+}


### PR DESCRIPTION
This fixes #214

There are some issues with how some extensions work in terms of inheritance where you can never exactly match the method signature of what you are extending. In this case a strict error is thrown which often gets translated into a failed test in PHPUnit. I have added a whitelist of classes that will bypass strict error checking. Until a better solution is provided upstream:

https://github.com/php-memcached-dev/php-memcached/issues/126