### PR TITLE
Fix Phake::resetStatic() post calls

### DIFF
--- a/src/Phake.php
+++ b/src/Phake.php
@@ -358,13 +358,16 @@ class Phake
     }
 
     /**
-     * Resets all calls and stubs on the given mock object
+     * Resets all calls and stubs on the given mock object and return the original class name
      *
      * @param Phake_IMock $mock
+     * @return string $name
      */
     public static function resetStatic(Phake_IMock $mock)
     {
-        self::getInfo(get_class($mock))->resetInfo();
+        $info = self::getInfo(get_class($mock));
+        $info->resetInfo();
+        return $info->getName();
     }
 
     /**

--- a/tests/PhakeTest.php
+++ b/tests/PhakeTest.php
@@ -1693,4 +1693,20 @@ class PhakeTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame($mock, $mock->foo());
     }
+
+    public function testResetStaticPostCall() {
+        $obj = new PhakeTest_StaticMethod;
+        $obj->className = Phake::mock('PhakeTest_ClassWithStaticMethod');
+        Phake::whenStatic($obj->className)->ask()->thenReturn('ASKED');
+
+        $val = $obj->askSomething();
+        Phake::verifyStatic($obj->className)->ask();
+
+        $this->assertEquals('ASKED', $val);
+
+        $obj->className = Phake::resetStatic($obj->className);
+
+        $val = $obj->askSomething();
+        $this->assertEquals('Asked', $val);
+    }
 }

--- a/tests/PhakeTest/ClassWithStaticMethod.php
+++ b/tests/PhakeTest/ClassWithStaticMethod.php
@@ -1,0 +1,8 @@
+<?php
+
+class PhakeTest_ClassWithStaticMethod 
+{
+    public static function ask() {
+        return 'Asked';
+    }
+}

--- a/tests/PhakeTest/StaticMethod.php
+++ b/tests/PhakeTest/StaticMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+class PhakeTest_StaticMethod
+{
+    public $className = 'PhakeTest_ClassWithStaticMethod';
+    
+    public function askSomething()
+    {
+        $className = $this->className;
+        return $className::ask();
+    }
+}


### PR DESCRIPTION
`Phake::resetStatic()` clears the internal states but did not return the original class name, this commit will address this issue backed by a followup test 
@mlively thoughts ?
