### PR TITLE
Added captureClones captor

### DIFF
--- a/src/Phake.php
+++ b/src/Phake.php
@@ -69,6 +69,11 @@ class Phake
     private static $loader;
 
     /**
+     * @var callable
+     */
+    public static $argumentCloner;
+
+    /**
      * Constants identifying supported clients
      */
     const CLIENT_DEFAULT = 'DEFAULT';
@@ -458,6 +463,22 @@ class Phake
 
 
     /**
+     * Returns a capturing matcher that is bound to store ALL of its calls in the variable passed in.
+     *
+     * $value will initially be set to an empty array;
+     *
+     * @param mixed $value - Will be set to the cloned values of the called argument.
+     *
+     * @return Phake_Matchers_ArgumentCaptor
+     */
+    public static function captureClones(&$value)
+    {
+        $captor = self::captureAll($value);
+        $captor->useClones();
+        return $captor;
+    }
+
+    /**
      * Returns a setter matcher that will set a reference parameter passed in as an argument to the
      * given value.
      *
@@ -671,5 +692,17 @@ class Phake
     public static function makeStaticsVisible(Phake_IMock $mock)
     {
         return new Phake_Proxies_StaticVisibilityProxy($mock);
+    }
+
+    public static function cloneArgument(&$arg)
+    {
+        if (!is_object($arg)) {
+            return $arg;
+        }
+
+        if(is_callable(static::$argumentCloner)) {
+            return call_user_func(static::$argumentCloner, $arg);
+        }
+        return clone $arg;
     }
 }

--- a/src/Phake/CallRecorder/Call.php
+++ b/src/Phake/CallRecorder/Call.php
@@ -65,6 +65,11 @@ class Phake_CallRecorder_Call
     private $arguments;
 
     /**
+     * @var array
+     */
+    private $clones;
+
+    /**
      * @param string|\Phake_IMock $context - The object the method was called on
      * @param string              $method - The method that was made
      * @param array               $arguments
@@ -74,6 +79,10 @@ class Phake_CallRecorder_Call
         $this->object     = $context;
         $this->method     = $method;
         $this->arguments  = $arguments;
+        $this->clones     = array();
+        foreach ($arguments as $argument) {
+            $this->clones[] = Phake::cloneArgument($argument);
+        }
     }
 
     /**
@@ -98,6 +107,14 @@ class Phake_CallRecorder_Call
     public function getArguments()
     {
         return $this->arguments;
+    }
+
+    /**
+     * @return array
+     */
+    public function getClones()
+    {
+        return $this->clones;
     }
 
     /**

--- a/src/Phake/CallRecorder/Verifier.php
+++ b/src/Phake/CallRecorder/Verifier.php
@@ -81,7 +81,8 @@ class Phake_CallRecorder_Verifier
      */
     public function verifyCall(Phake_CallRecorder_CallExpectation $expectation)
     {
-        $matcher = new Phake_Matchers_MethodMatcher($expectation->getMethod(), $expectation->getArgumentMatcher());
+        $expectationMatcher = $expectation->getArgumentMatcher();
+        $matcher = new Phake_Matchers_MethodMatcher($expectation->getMethod(), $expectationMatcher);
         $calls   = $this->recorder->getAllCalls();
 
         $matchedCalls     = array();
@@ -91,7 +92,12 @@ class Phake_CallRecorder_Verifier
             /* @var $call Phake_CallRecorder_Call */
             if ($call->getObject() === $expectation->getObject()) {
                 $obj_interactions = true;
-                $args             = $call->getArguments();
+                if ($expectationMatcher && $expectationMatcher->isUsingClones()) {
+                    $args = $call->getClones();
+                } else {
+                    $args = $call->getArguments();
+                }
+
                 try
                 {
                     $matcher->assertMatches($call->getMethod(), $args);

--- a/src/Phake/Matchers/AbstractChainableArgumentMatcher.php
+++ b/src/Phake/Matchers/AbstractChainableArgumentMatcher.php
@@ -49,6 +49,8 @@ abstract class Phake_Matchers_AbstractChainableArgumentMatcher implements Phake_
 {
     private $nextMatcher;
 
+    protected $useClones = false;
+
     public function setNextMatcher(Phake_Matchers_IChainableArgumentMatcher $nextMatcher)
     {
         $nextMatcher->assertPreviousMatcher($this);
@@ -70,5 +72,20 @@ abstract class Phake_Matchers_AbstractChainableArgumentMatcher implements Phake_
      */
     public function assertPreviousMatcher(Phake_Matchers_IChainableArgumentMatcher $matcher)
     {
+    }
+
+    public function isUsingClones()
+    {
+        return $this->useClones;
+    }
+
+    public function useClones()
+    {
+        $this->useClones = true;
+    }
+
+    public function useObjects()
+    {
+        $this->useClones = false;
     }
 }

--- a/src/Phake/Matchers/IChainableArgumentMatcher.php
+++ b/src/Phake/Matchers/IChainableArgumentMatcher.php
@@ -81,6 +81,12 @@ interface Phake_Matchers_IChainableArgumentMatcher
     public function assertPreviousMatcher(Phake_Matchers_IChainableArgumentMatcher $matcher);
 
     /**
+     * Returns whether matcher should use cloned objects or original ones
+     * @return bool
+     */
+    public function isUsingClones();
+
+    /**
      * Returns a human readable description of the argument matcher
      * @return string
      */


### PR DESCRIPTION
Allows to assert objects, captured on consecutive calls, when the same object is used as a parameter.

I faced this issue when mocked Doctrine ORM to assert that entity is being persisted first to get UID generated, then changed, and persisted again.  Since objects are passed by reference, any changes in the object also change it in the captor. A bit more details on stackoverflow: http://stackoverflow.com/questions/38566796/phake-framework-how-to-clone-objects-on-captureall

