### PR TITLE
Fix "Mocking Static Methods" documentation example

### DIFF
--- a/docs/mocking-statics.rst
+++ b/docs/mocking-statics.rst
@@ -89,7 +89,7 @@ Now you can mock logData as follows:
             $foo = new Foo();
             $foo->logger = Phake::mock('Logger');
             $foo->doSomething();
-            Phake::verifyStatic($foo->logger)->logData(Phake::anyParameter());
+            Phake::verifyStatic($foo->logger)->logData(Phake::anyParameters());
         }
     }
 

--- a/docs/mocking-statics.rst
+++ b/docs/mocking-statics.rst
@@ -89,7 +89,7 @@ Now you can mock logData as follows:
             $foo = new Foo();
             $foo->logger = Phake::mock('Logger');
             $foo->doSomething();
-            Phake::verify($foo->logger)->logData(Phake::anyParameter());
+            Phake::verifyStatic($foo->logger)->logData(Phake::anyParameter());
         }
     }
 


### PR DESCRIPTION
This example in the documentation had two small errors.
- Instead of using `Phake::verifyStatic()`, it used `Phake::verify()`.
- `Phake::anyParameter()` should be `Phake::anyParameters()`.