### PR TITLE
Fixes #239 - thenDoNothing() missing on Phake_Proxies_AnswerCollectionProxy

### DIFF
--- a/src/Phake/Proxies/AnswerCollectionProxy.php
+++ b/src/Phake/Proxies/AnswerCollectionProxy.php
@@ -47,7 +47,7 @@
  *
  * @author Mike Lively <m@digitalsandwich.com>
  */
-class Phake_Proxies_AnswerCollectionProxy implements Phake_Stubber_IAnswerContainer
+class Phake_Proxies_AnswerCollectionProxy implements Phake_Stubber_IAnswerContainer, Phake_Proxies_AnswerProxyInterface
 {
     /**
      * @var Phake_Stubber_AnswerCollection
@@ -127,6 +127,32 @@ class Phake_Proxies_AnswerCollectionProxy implements Phake_Stubber_IAnswerContai
     public function captureReturnTo(&$captor)
     {
         $this->collection->addAnswer(new Phake_Stubber_Answers_ParentDelegate($captor));
+        return $this;
+    }
+
+    /**
+     * Binds a callback answer to the method.
+     *
+     * @param callback $value
+     *
+     * @throws InvalidArgumentException
+     * @return Phake_Stubber_IAnswerContainer
+     */
+    public function thenReturnCallback($value)
+    {
+        $this->collection->addAnswer(new Phake_Stubber_Answers_LambdaAnswer($value));
+        return $this;
+    }
+
+    public function thenDoNothing()
+    {
+        $this->collection->addAnswer(new Phake_Stubber_Answers_NoAnswer());
+        return $this;
+    }
+
+    public function thenReturnSelf()
+    {
+        $this->collection->addAnswer(new Phake_Stubber_Answers_SelfAnswer());
         return $this;
     }
 

--- a/src/Phake/Proxies/AnswerProxyInterface.php
+++ b/src/Phake/Proxies/AnswerProxyInterface.php
@@ -1,26 +1,26 @@
 <?php
-/* 
+/*
  * Phake - Mocking Framework
- * 
+ *
  * Copyright (c) 2010-2012, Mike Lively <m@digitalsandwich.com>
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  *  *  Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
- * 
+ *
  *  *  Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in
  *     the documentation and/or other materials provided with the
  *     distribution.
- * 
+ *
  *  *  Neither the name of Mike Lively nor the names of his
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -33,7 +33,7 @@
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  * @category   Testing
  * @package    Phake
  * @author     Mike Lively <m@digitalsandwich.com>
@@ -43,22 +43,12 @@
  */
 
 /**
- * A proxy class to provide a fluent interface into the answer binder.
- *
+ * Defines an interface for anything that supports answers
+ * 
  * @author Mike Lively <m@digitalsandwich.com>
  */
-class Phake_Proxies_AnswerBinderProxy implements Phake_Proxies_AnswerProxyInterface
+interface Phake_Proxies_AnswerProxyInterface
 {
-    /**
-     * @var Phake_Stubber_IAnswerBinder
-     */
-    private $binder;
-
-    public function __construct(Phake_Stubber_IAnswerBinder $binder)
-    {
-        $this->binder = $binder;
-    }
-
     /**
      * Binds a static answer to the method and object in the proxied binder.
      *
@@ -66,10 +56,7 @@ class Phake_Proxies_AnswerBinderProxy implements Phake_Proxies_AnswerProxyInterf
      *
      * @return Phake_Stubber_IAnswerContainer
      */
-    public function thenReturn($value)
-    {
-        return $this->binder->bindAnswer(new Phake_Stubber_Answers_StaticAnswer($value));
-    }
+    public function thenReturn($value);
 
     /**
      * Binds a Lambda answer to the method
@@ -80,11 +67,7 @@ class Phake_Proxies_AnswerBinderProxy implements Phake_Proxies_AnswerProxyInterf
      * @throws InvalidArgumentException
      * @return Phake_Stubber_IAnswerContainer
      */
-    public function thenGetReturnByLambda($value)
-    {
-        trigger_error('Use thenReturnCallback instead.', E_USER_DEPRECATED);
-        return $this->thenReturnCallback($value);
-    }
+    public function thenGetReturnByLambda($value);
 
     /**
      * Binds a callback answer to the method.
@@ -94,23 +77,14 @@ class Phake_Proxies_AnswerBinderProxy implements Phake_Proxies_AnswerProxyInterf
      * @throws InvalidArgumentException
      * @return Phake_Stubber_IAnswerContainer
      */
-    public function thenReturnCallback($value)
-    {
-        if (!is_callable($value)) {
-            throw new InvalidArgumentException("Given lambda is not callable");
-        }
+    public function thenReturnCallback($value);
 
-        return $this->binder->bindAnswer(new Phake_Stubber_Answers_LambdaAnswer($value));
-    }
 
     /**
      * Binds a delegated call that will call a given method's parent.
      * @return Phake_Stubber_IAnswerContainer
      */
-    public function thenCallParent()
-    {
-        return $this->binder->bindAnswer(new Phake_Stubber_Answers_ParentDelegate());
-    }
+    public function thenCallParent();
 
     /**
      * Binds an exception answer to the method and object in the proxied binder.
@@ -119,10 +93,7 @@ class Phake_Proxies_AnswerBinderProxy implements Phake_Proxies_AnswerProxyInterf
      *
      * @return Phake_Stubber_IAnswerContainer
      */
-    public function thenThrow(Exception $value)
-    {
-        return $this->binder->bindAnswer(new Phake_Stubber_Answers_ExceptionAnswer($value));
-    }
+    public function thenThrow(Exception $value);
 
     /**
      * Binds a delegated call that will call a given method's parent while capturing that value to the passed in variable.
@@ -131,18 +102,9 @@ class Phake_Proxies_AnswerBinderProxy implements Phake_Proxies_AnswerProxyInterf
      *
      * @return Phake_Stubber_IAnswerContainer
      */
-    public function captureReturnTo(&$captor)
-    {
-        return $this->binder->bindAnswer(new Phake_Stubber_Answers_ParentDelegate($captor));
-    }
+    public function captureReturnTo(&$captor);
 
-    public function thenDoNothing()
-    {
-        return $this->binder->bindAnswer(new Phake_Stubber_Answers_NoAnswer());
-    }
+    public function thenDoNothing();
 
-    public function thenReturnSelf()
-    {
-        return $this->binder->bindAnswer(new Phake_Stubber_Answers_SelfAnswer());
-    }
+    public function thenReturnSelf();
 }

--- a/tests/PhakeTest.php
+++ b/tests/PhakeTest.php
@@ -1735,4 +1735,17 @@ class PhakeTest extends TestCase
         $val = $obj->askSomething();
         $this->assertEquals('Asked', $val);
     }
+
+    /**
+     * For #239
+     */
+    public function testChainingDoNothing()
+    {
+        $mock = Phake::mock(PhakeTest_MockedClass::class);
+
+        Phake::when($mock)->foo->thenReturn(42)->thenDoNothing();
+
+        $this->assertEquals(42, $mock->foo());
+        $this->assertNull($mock->foo());
+    }
 }


### PR DESCRIPTION
Basically dropped all of the answers into an interface and implemented it on the answercollection and answerbinder proxies.