### PR TITLE
Lazily evaluate the diff instead of adding it to every message

### DIFF
--- a/src/Phake/CallRecorder/Verifier.php
+++ b/src/Phake/CallRecorder/Verifier.php
@@ -101,7 +101,7 @@ class Phake_CallRecorder_Verifier
                 catch (Phake_Exception_MethodMatcherException $e)
                 {
                     if ($call->getMethod() == $expectation->getMethod()) {
-                        $message = $e->getMessage();
+                        $message = $e->getMessageWithComparisonDiff();
                         if (strlen($message))
                         {
                             $message = "\n{$message}";

--- a/src/Phake/Exception/MethodMatcherException.php
+++ b/src/Phake/Exception/MethodMatcherException.php
@@ -33,4 +33,23 @@ class Phake_Exception_MethodMatcherException extends Exception
     {
         return $this->argument;
     }
+
+    /**
+     * Get the message, but include the comparison diff.
+     *
+     * @internal This is so we can lazy generate the comparison message.
+     * @return string
+     */
+    public function getMessageWithComparisonDiff()
+    {
+        $previous = $this;
+
+        while($previous = $previous->getPrevious()) {
+            if ($previous instanceof \SebastianBergmann\Comparator\ComparisonFailure) {
+                return trim($this->getMessage() . "\n" . $previous->getDiff());
+            }
+        }
+
+        return $this->getMessage();
+    }
 }

--- a/src/Phake/Matchers/EqualsMatcher.php
+++ b/src/Phake/Matchers/EqualsMatcher.php
@@ -76,6 +76,13 @@ class Phake_Matchers_EqualsMatcher extends Phake_Matchers_SingleArgumentMatcher
      */
     protected  function matches(&$argument)
     {
+        if ($this->value === $argument) {
+            /*
+             * If they are identical, skip the initialization of the Comparator factory and its objects.
+             */
+            return;
+        }
+
         try
         {
             $compare = $this->comparatorFactory->getComparatorFor($this->value, $argument);
@@ -83,7 +90,7 @@ class Phake_Matchers_EqualsMatcher extends Phake_Matchers_SingleArgumentMatcher
         }
         catch (\SebastianBergmann\Comparator\ComparisonFailure $e)
         {
-            throw new Phake_Exception_MethodMatcherException(trim($e->getMessage() . "\n" . $e->getDiff()), $e);
+            throw new Phake_Exception_MethodMatcherException($e->getMessage(), $e);
         }
     }
 

--- a/tests/Phake/CallRecorder/VerifierTest.php
+++ b/tests/Phake/CallRecorder/VerifierTest.php
@@ -364,7 +364,6 @@ Other Invocations:
                 . "  \n"
                 . "  --- Expected\n"
                 . "  +++ Actual\n"
-                . "  @@ @@\n"
                 . "  -'test'\n"
                 . "  +'bar'\n"
                 . "===\n"


### PR DESCRIPTION
Matching is very slow when multiple calls to verified function with different complex objects, because every time a mocked method is invoked, the entire diff is generated.

E.g.

```
Phake::when($a)->myMethod($complexObject);
```

If there are many calls to myMethod() (with different objects), a diff is generated every time. This diff is not cheap if this is a complex object.

This PR moves the generation of the diff to a later step, when there actually isn't a match and the error message has to be generated. 