### PR TITLE
Use the global Comparator factory. 

### DIFF
--- a/src/Phake.php
+++ b/src/Phake.php
@@ -448,7 +448,7 @@ class Phake
      */
     public static function equalTo($value)
     {
-        return new Phake_Matchers_EqualsMatcher($value, new \SebastianBergmann\Comparator\Factory());
+        return new Phake_Matchers_EqualsMatcher($value, \SebastianBergmann\Comparator\Factory::getInstance());
     }
 
     /**

--- a/src/Phake/Matchers/Factory.php
+++ b/src/Phake/Matchers/Factory.php
@@ -52,7 +52,7 @@ class Phake_Matchers_Factory
 
     public function __construct()
     {
-        $this->comparatorFactory = new \SebastianBergmann\Comparator\Factory();
+        $this->comparatorFactory =  \SebastianBergmann\Comparator\Factory::getInstance();
     }
 
     /**

--- a/tests/Phake/CallRecorder/VerifierTest.php
+++ b/tests/Phake/CallRecorder/VerifierTest.php
@@ -149,8 +149,8 @@ class Phake_CallRecorder_VerifierTest extends TestCase
      */
     public function testVerifierDoesNotFindCallWithUnmatchedArguments()
     {
-        $matcher1 = new Phake_Matchers_EqualsMatcher('test', new \SebastianBergmann\Comparator\Factory());
-        $matcher2 = new Phake_Matchers_EqualsMatcher('test', new \SebastianBergmann\Comparator\Factory());
+        $matcher1 = new Phake_Matchers_EqualsMatcher('test', \SebastianBergmann\Comparator\Factory::getInstance());
+        $matcher2 = new Phake_Matchers_EqualsMatcher('test', \SebastianBergmann\Comparator\Factory::getInstance());
         $matcher1->setNextMatcher($matcher2);
         $expectation = new Phake_CallRecorder_CallExpectation(
             $this->obj,
@@ -337,7 +337,7 @@ Other Invocations:
         $expectation = new Phake_CallRecorder_CallExpectation(
             $this->obj,
             'foo',
-            new Phake_Matchers_EqualsMatcher('test', new \SebastianBergmann\Comparator\Factory()),
+            new Phake_Matchers_EqualsMatcher('test', \SebastianBergmann\Comparator\Factory::getInstance()),
             $this->verifierMode
         );
 

--- a/tests/Phake/Matchers/EqualsMatcherTest.php
+++ b/tests/Phake/Matchers/EqualsMatcherTest.php
@@ -59,7 +59,7 @@ class Phake_Matchers_EqualsMatcherTest extends TestCase
      */
     public function setUp()
     {
-        $this->matcher = new Phake_Matchers_EqualsMatcher('foo', new \SebastianBergmann\Comparator\Factory());
+        $this->matcher = new Phake_Matchers_EqualsMatcher('foo', \SebastianBergmann\Comparator\Factory::getInstance());
     }
 
     /**
@@ -93,7 +93,7 @@ class Phake_Matchers_EqualsMatcherTest extends TestCase
      */
     public function testToStringOnNonStringableObject()
     {
-        $this->matcher = new Phake_Matchers_EqualsMatcher(new stdClass, new \SebastianBergmann\Comparator\Factory());
+        $this->matcher = new Phake_Matchers_EqualsMatcher(new stdClass, \SebastianBergmann\Comparator\Factory::getInstance());
 
         $this->assertEquals('equal to <object:stdClass>', $this->matcher->__toString());
     }
@@ -106,7 +106,7 @@ class Phake_Matchers_EqualsMatcherTest extends TestCase
         $a             = new stdClass;
         $a->b          = new stdClass;
         $a->b->a       = $a;
-        $this->matcher = new Phake_Matchers_EqualsMatcher($a, new \SebastianBergmann\Comparator\Factory());
+        $this->matcher = new Phake_Matchers_EqualsMatcher($a, \SebastianBergmann\Comparator\Factory::getInstance());
 
         $c       = new stdClass();
         $c->b    = new stdClass();
@@ -119,7 +119,7 @@ class Phake_Matchers_EqualsMatcherTest extends TestCase
 
     public function testDifferentClassObjects()
     {
-        $this->matcher = new Phake_Matchers_EqualsMatcher(new PhakeTest_A(), new \SebastianBergmann\Comparator\Factory());
+        $this->matcher = new Phake_Matchers_EqualsMatcher(new PhakeTest_A(), \SebastianBergmann\Comparator\Factory::getInstance());
 
         $value = array(new PhakeTest_B());
         $this->expectException('Exception');
@@ -128,7 +128,7 @@ class Phake_Matchers_EqualsMatcherTest extends TestCase
 
     public function testArraysWithDifferentCounts()
     {
-        $this->matcher = new Phake_Matchers_EqualsMatcher(array(1), new \SebastianBergmann\Comparator\Factory());
+        $this->matcher = new Phake_Matchers_EqualsMatcher(array(1), \SebastianBergmann\Comparator\Factory::getInstance());
 
         $test = array(array(1, 2));
         $this->expectException('Phake_Exception_MethodMatcherException');
@@ -137,7 +137,7 @@ class Phake_Matchers_EqualsMatcherTest extends TestCase
 
     public function testArraysWithDifferentKeys()
     {
-        $this->matcher = new Phake_Matchers_EqualsMatcher(array('one' => 1), new \SebastianBergmann\Comparator\Factory());
+        $this->matcher = new Phake_Matchers_EqualsMatcher(array('one' => 1), \SebastianBergmann\Comparator\Factory::getInstance());
 
         $test = array(array('two' => 1));
         $this->expectException('Exception');

--- a/tests/Phake/Proxies/CallVerifierProxyTest.php
+++ b/tests/Phake/Proxies/CallVerifierProxyTest.php
@@ -69,8 +69,8 @@ class Phake_Proxies_CallVerifierProxyTest extends TestCase
         $this->client     = new Phake_Client_Default();
         $this->obj        = new Phake_CallRecorder_Recorder();
 
-        $matcher1 = new Phake_Matchers_EqualsMatcher('foo', new \SebastianBergmann\Comparator\Factory());
-        $matcher2 = new Phake_Matchers_EqualsMatcher(array(), new \SebastianBergmann\Comparator\Factory());
+        $matcher1 = new Phake_Matchers_EqualsMatcher('foo', \SebastianBergmann\Comparator\Factory::getInstance());
+        $matcher2 = new Phake_Matchers_EqualsMatcher(array(), \SebastianBergmann\Comparator\Factory::getInstance());
         $matcher1->setNextMatcher($matcher2);
         $this->proxy = new Phake_Proxies_CallVerifierProxy($matcher1, $this->client, false);
 
@@ -91,8 +91,8 @@ class Phake_Proxies_CallVerifierProxyTest extends TestCase
 
     public function testStaticIsCalledOn()
     {
-        $matcher1 = new Phake_Matchers_EqualsMatcher('foo', new \SebastianBergmann\Comparator\Factory());
-        $matcher2 = new Phake_Matchers_EqualsMatcher(array(), new \SebastianBergmann\Comparator\Factory());
+        $matcher1 = new Phake_Matchers_EqualsMatcher('foo', \SebastianBergmann\Comparator\Factory::getInstance());
+        $matcher2 = new Phake_Matchers_EqualsMatcher(array(), \SebastianBergmann\Comparator\Factory::getInstance());
         $matcher1->setNextMatcher($matcher2);
         $this->proxy = new Phake_Proxies_CallVerifierProxy($matcher1, $this->client, true);
 

--- a/tests/Phake/Proxies/VerifierProxyTest.php
+++ b/tests/Phake/Proxies/VerifierProxyTest.php
@@ -136,7 +136,7 @@ class Phake_Proxies_VerifierProxyTest extends TestCase
      */
     public function testProxyTransformsNonMatchersToEqualsMatcher()
     {
-        $argumentMatcher = new Phake_Matchers_EqualsMatcher('test', new \SebastianBergmann\Comparator\Factory());
+        $argumentMatcher = new Phake_Matchers_EqualsMatcher('test', \SebastianBergmann\Comparator\Factory::getInstance());
         Phake::when($this->verifier)->verifyCall(Phake::anyParameters())->thenReturn(
             new Phake_CallRecorder_VerifierResult(true, array(Phake::mock('Phake_CallRecorder_CallInfo')))
         );


### PR DESCRIPTION
Saves lots of object initialization but more importantly allows us to register customer Comparators.