### PR TITLE
Handle missing parameter names returned from ReflectionParameter

### DIFF
--- a/src/Phake/ClassGenerator/MockClass.php
+++ b/src/Phake/ClassGenerator/MockClass.php
@@ -560,7 +560,7 @@ class {$newClassName} {$extends}
                 break;
             }
             else {
-                $copies .= "if ({$pos} < \$__PHAKE_numArgs) \$__PHAKE_args[] =& \${$parameter->getName()};\n\t\t";
+                $copies .= "if ({$pos} < \$__PHAKE_numArgs) \$__PHAKE_args[] =& \${$this->getParameterName($parameter)};\n\t\t";
             }
         }
 
@@ -619,7 +619,21 @@ class {$newClassName} {$extends}
             $default = ' = null';
         }
 
-        return $type . ($parameter->isPassedByReference() ? '&' : '') . $variadic . '$' . $parameter->getName() . $default;
+        return $type . ($parameter->isPassedByReference() ? '&' : '') . $variadic . '$' . $this->getParameterName($parameter) . $default;
+    }
+
+    /**
+     * Get the name of a ReflectionParameter - sometimes they'll return null, if
+     * that happens we generate a name based on the offset in the method
+     * signature
+     *
+     * @param ReflectionParameter $parameter
+     * @return string
+     */
+    protected function getParameterName(ReflectionParameter $parameter) {
+        $name = $parameter->getName();
+        if (!empty($name)) return $name;
+        return "param".$parameter->getPosition();
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/mlively/Phake/issues/259

I based this off the v2.3.2 tag - sorry I couldn't figure out which branch belonged to the stable branches (master requires PHP 7+ which is too new for us, i.e we're support PHP 5.4 - 7.1 still).

The way I'm testing `copyMethodParameters` is pretty dodgy, but I couldn't come up with anything better, feedback welcome.