### PR TITLE
Fix assertEquals() parameters

### DIFF
--- a/docs/mocks.rst
+++ b/docs/mocks.rst
@@ -206,7 +206,7 @@ same code using ``Phake::makeVisible()``.
             $oldClass = new Phake::partialMock('MyReallyTerribleOldClass');
 
             $data = Phake::makeVisible($oldClass)->cleanRowContent($dbRow);
-            $this->assertEquals($expectedValue, $dbRow);
+            $this->assertEquals($expectedValue, $data);
         }
     }
 


### PR DESCRIPTION
One of the example proposed had wrong parameters on assertEquals()