### PR TITLE
Performance: replace uniqid with random_bytes

### DIFF
--- a/src/Phake/Facade.php
+++ b/src/Phake/Facade.php
@@ -129,7 +129,7 @@ class Phake_Facade
             $ns_parts        = explode('\\', $base);
             $base            = array_pop($ns_parts);
             //Cygwin will drop a period from uniqid
-            $base_class_name[] = str_replace('.', '', uniqid($base . '_PHAKE'));
+            $base_class_name[] = $base . '_PHAKE' . bin2hex(random_bytes(7));
         }
 
         $i = 1;

--- a/src/Phake/Facade.php
+++ b/src/Phake/Facade.php
@@ -128,7 +128,6 @@ class Phake_Facade
         {
             $ns_parts        = explode('\\', $base);
             $base            = array_pop($ns_parts);
-            //Cygwin will drop a period from uniqid
             $base_class_name[] = $base . '_PHAKE' . bin2hex(random_bytes(7));
         }
 

--- a/src/Phake/Mock/Info.php
+++ b/src/Phake/Mock/Info.php
@@ -68,7 +68,7 @@ class Phake_Mock_Info {
 
     public function __construct($name, Phake_CallRecorder_Recorder $recorder, Phake_Stubber_StubMapper $mapper, Phake_Stubber_IAnswer $defaultAnswer)
     {
-        $this->uniqId = uniqid('', true);
+        $this->uniqId = bin2hex(random_bytes(7));
         $this->recorder = $recorder;
         $this->mapper = $mapper;
         $this->answer = $defaultAnswer;

--- a/tests/Phake/ClassGenerator/MockClassTest.php
+++ b/tests/Phake/ClassGenerator/MockClassTest.php
@@ -575,7 +575,7 @@ class Phake_ClassGenerator_MockClassTest extends TestCase
 
     public function testDestructMocked()
     {
-        $newClassName = __CLASS__ . '_TestClass' . uniqid();
+        $newClassName = __CLASS__ . '_TestClass' . bin2hex(random_bytes(7));
         $mockedClass  = 'PhakeTest_DestructorClass';
         $this->classGen->generate($newClassName, $mockedClass, $this->infoRegistry);
 
@@ -644,7 +644,7 @@ class Phake_ClassGenerator_MockClassTest extends TestCase
 
     public function testGeneratedMockClassHasStaticInfo()
     {
-        $newClassName = __CLASS__ . '_TestClass' . uniqid();
+        $newClassName = __CLASS__ . '_TestClass' . bin2hex(random_bytes(7));
         $mockedClass  = 'stdClass';
         $this->classGen->generate($newClassName, $mockedClass, $this->infoRegistry);
 


### PR DESCRIPTION
`uniquid()` is not without its flaws - but most importantly it is rather slow. 

![screen shot 2018-10-19 at 13 36 45](https://user-images.githubusercontent.com/701299/47216120-2d207800-d3a4-11e8-9749-e312ca481419.png)

This PR replaces uniqid with `bin2hex(random_bytes(7))` which gives a comparable result. 