### PR TITLE
Use ReflectionProperty to fix parent mock annotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 dist: trusty
 
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
@@ -18,13 +17,11 @@ script:
   - ./bin/phpunit --coverage-clover=build/logs/clover.xml
 
 matrix:
-  exclude:
-    - php: 7.0
-      env: PHPUNIT_VERSION=7.5
-    - php: 7.0
-      env: PHPUNIT_VERSION=8.1
-    - php: 7.1
-      env: PHPUNIT_VERSION=8.1
+  allow_failures:
+    - env: PHPUNIT_VERSION=8.1
+#  exclude:
+#    - php: 7.1
+#      env: PHPUNIT_VERSION=8.1
 
 install:
   - composer require --dev phpunit/phpunit:${PHPUNIT_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,8 @@ php:
   - nightly
 
 env:
-  - PHPUNIT_VERSION=6.0.x-dev
-  - PHPUNIT_VERSION=6.1.x-dev
-  - PHPUNIT_VERSION=6.2.x-dev
-  - PHPUNIT_VERSION=6.3.x-dev
-  - PHPUNIT_VERSION=7.2.x-dev
+  - PHPUNIT_VERSION=7.5
+  - PHPUNIT_VERSION=8.1
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ dist: trusty
 php:
   - 7.0
   - 7.1
-  - nightly
+  - 7.2
+  - 7.3
 
 env:
+  - PHPUNIT_VERSION=6.5.14
   - PHPUNIT_VERSION=7.5
   - PHPUNIT_VERSION=8.1
 
@@ -16,12 +18,13 @@ script:
   - ./bin/phpunit --coverage-clover=build/logs/clover.xml
 
 matrix:
-  allow_failures:
-    - php: nightly
-    - env: PHPUNIT_VERSION=6.3.x-dev
   exclude:
     - php: 7.0
-      env: PHPUNIT_VERSION=7.2.x-dev
+      env: PHPUNIT_VERSION=7.5
+    - php: 7.0
+      env: PHPUNIT_VERSION=8.1
+    - php: 7.1
+      env: PHPUNIT_VERSION=8.1
 
 install:
   - composer require --dev phpunit/phpunit:${PHPUNIT_VERSION}

--- a/src/Phake/Annotation/Reader.php
+++ b/src/Phake/Annotation/Reader.php
@@ -2,26 +2,26 @@
 
 /*
  * Phake - Mocking Framework
- * 
+ *
  * Copyright (c) 2010, Mike Lively <mike.lively@sellingsource.com>
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  *  *  Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
- * 
+ *
  *  *  Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in
  *     the documentation and/or other materials provided with the
  *     distribution.
- * 
+ *
  *  *  Neither the name of Mike Lively nor the names of his
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -34,7 +34,7 @@
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  * @category   Testing
  * @package    Phake
  * @author     Mike Lively <m@digitalsandwich.com>
@@ -82,7 +82,7 @@ class Phake_Annotation_Reader
      *
      * @param string $annotation
      *
-     * @return array
+     * @return ReflectionProperty[]
      */
     public function getPropertiesWithAnnotation($annotation)
     {
@@ -91,7 +91,7 @@ class Phake_Annotation_Reader
             $annotations = $this->getPropertyAnnotations($property->getName());
 
             if (array_key_exists($annotation, $annotations)) {
-                $properties[] = $property->getName();
+                $properties[] = $property;
             }
         }
         return $properties;
@@ -106,7 +106,7 @@ class Phake_Annotation_Reader
      *
      * @return array
      */
-    private function readReflectionAnnotation($reflVar)
+    public function readReflectionAnnotation($reflVar)
     {
         $comment = $reflVar->getDocComment();
 

--- a/tests/Phake/Annotation/MockInitializerParentTestCase.php
+++ b/tests/Phake/Annotation/MockInitializerParentTestCase.php
@@ -43,54 +43,19 @@
  * @link       http://www.digitalsandwich.com/
  */
 
-/**
- * Initializes all properties of a given object that have the @Mock annotation.
- *
- * The class can be passed to the Mock annotation or it can also read the standard @var -annotation.
- *
- * In either case the fully qualified class name should be used. The use statements are not observed.
- */
-class Phake_Annotation_MockInitializer
+use PhakeTest\NamespacedClass;
+use PHPUnit\Framework\TestCase;
+
+abstract class Phake_Annotation_MockInitializerParentTestCase extends TestCase
 {
-    public function initialize($object)
+    /**
+     * @Mock
+     * @var NamespacedClass
+     */
+    protected $testMock;
+
+    protected function setUp()
     {
-        $reflectionClass = new ReflectionClass($object);
-        $reader          = new Phake_Annotation_Reader($reflectionClass);
-
-        if ($this->useDoctrineParser()) {
-            $parser = new \Doctrine\Common\Annotations\PhpParser();
-        }
-
-        $properties = $reader->getPropertiesWithAnnotation('Mock');
-
-        foreach ($properties as $property) {
-            $annotations = $reader->readReflectionAnnotation($property);
-
-            if ($annotations['Mock'] !== true) {
-                $mockedClass = $annotations['Mock'];
-            } else {
-                $mockedClass = $annotations['var'];
-            }
-
-            if (isset($parser)) {
-                // Ignore it if the class start with a backslash
-                if (substr($mockedClass, 0, 1) !== '\\') {
-                    $useStatements = $parser->parseClass($property->getDeclaringClass());
-                    $key           = strtolower($mockedClass);
-
-                    if (array_key_exists($key, $useStatements)) {
-                        $mockedClass = $useStatements[$key];
-                    }
-                }
-            }
-
-            $property->setAccessible(true);
-            $property->setValue($object, Phake::mock($mockedClass));
-        }
-    }
-
-    protected function useDoctrineParser()
-    {
-        return version_compare(PHP_VERSION, "5.3.3", ">=") && class_exists('Doctrine\Common\Annotations\PhpParser');
+        Phake::initAnnotations($this);
     }
 }

--- a/tests/Phake/Annotation/MockInitializerSubclassTest.php
+++ b/tests/Phake/Annotation/MockInitializerSubclassTest.php
@@ -43,54 +43,12 @@
  * @link       http://www.digitalsandwich.com/
  */
 
-/**
- * Initializes all properties of a given object that have the @Mock annotation.
- *
- * The class can be passed to the Mock annotation or it can also read the standard @var -annotation.
- *
- * In either case the fully qualified class name should be used. The use statements are not observed.
- */
-class Phake_Annotation_MockInitializer
+require_once 'MockInitializerParentTestCase.php';
+
+class Phake_Annotation_MockInitializerSubclassTest extends Phake_Annotation_MockInitializerParentTestCase
 {
-    public function initialize($object)
+    public function testAnnotationsReadFromParent()
     {
-        $reflectionClass = new ReflectionClass($object);
-        $reader          = new Phake_Annotation_Reader($reflectionClass);
-
-        if ($this->useDoctrineParser()) {
-            $parser = new \Doctrine\Common\Annotations\PhpParser();
-        }
-
-        $properties = $reader->getPropertiesWithAnnotation('Mock');
-
-        foreach ($properties as $property) {
-            $annotations = $reader->readReflectionAnnotation($property);
-
-            if ($annotations['Mock'] !== true) {
-                $mockedClass = $annotations['Mock'];
-            } else {
-                $mockedClass = $annotations['var'];
-            }
-
-            if (isset($parser)) {
-                // Ignore it if the class start with a backslash
-                if (substr($mockedClass, 0, 1) !== '\\') {
-                    $useStatements = $parser->parseClass($property->getDeclaringClass());
-                    $key           = strtolower($mockedClass);
-
-                    if (array_key_exists($key, $useStatements)) {
-                        $mockedClass = $useStatements[$key];
-                    }
-                }
-            }
-
-            $property->setAccessible(true);
-            $property->setValue($object, Phake::mock($mockedClass));
-        }
-    }
-
-    protected function useDoctrineParser()
-    {
-        return version_compare(PHP_VERSION, "5.3.3", ">=") && class_exists('Doctrine\Common\Annotations\PhpParser');
+        $this->assertNotNull($this->testMock);
     }
 }

--- a/tests/Phake/Annotation/ReaderTest.php
+++ b/tests/Phake/Annotation/ReaderTest.php
@@ -96,8 +96,7 @@ class Phake_Annotation_ReaderTest extends TestCase
             'emptyVar',
             'reader',
         );
-        sort($properties);
-        $this->assertEquals($expectedProperties, $properties);
+        $this->assertContains($properties[0]->getName(), $expectedProperties);
+        $this->assertContains($properties[1]->getName(), $expectedProperties);
     }
 }
-

--- a/tests/Phake/ClassGenerator/MockClassTest.php
+++ b/tests/Phake/ClassGenerator/MockClassTest.php
@@ -546,7 +546,7 @@ class Phake_ClassGenerator_MockClassTest extends TestCase
         try {
             $mock = Phake::mock('PhakeTest_FinalClass');
             $this->fail("The mocked final method did not throw an exception");
-        } catch(InvalidArgumentException $actualException) {
+        } catch (InvalidArgumentException $actualException) {
             $this->assertEquals($actualException, $expectedException);
         }
     }
@@ -605,7 +605,7 @@ class Phake_ClassGenerator_MockClassTest extends TestCase
         try {
             $mock = $this->classGen->instantiate($newClassName, $recorder, $mapper, $answer);
             $this->assertInstanceOf('PhakeTest_SerializableClass', $mock);
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             $this->fail("Can't instantiate Serializable Object");
         }
     }
@@ -623,10 +623,9 @@ class Phake_ClassGenerator_MockClassTest extends TestCase
     /**
      * Ensure that 'callable' type hints in method parameters are supported.
      */
-    public function testCallableTypeHint ()
+    public function testCallableTypeHint()
     {
-        if (!version_compare(PHP_VERSION, '5.4', '>='))
-        {
+        if (!version_compare(PHP_VERSION, '5.4', '>=')) {
             $this->markTestSkipped('callable typehint require PHP 5.4');
         }
 
@@ -666,7 +665,7 @@ class Phake_ClassGenerator_MockClassTest extends TestCase
         $this->classGen->generate($newClassName, $mockedClass, $this->infoRegistry);
 
         Phake::verify($this->infoRegistry)->addInfo($newClassName::$__PHAKE_staticInfo);
-	}
+    }
 
     /**
      * Test that the generated mock has the same doc mocked class
@@ -689,8 +688,7 @@ class Phake_ClassGenerator_MockClassTest extends TestCase
 
     public function testStubbingVariadics()
     {
-        if (version_compare(phpversion(), '5.6.0') < 0)
-        {
+        if (version_compare(phpversion(), '5.6.0') < 0) {
             $this->markTestSkipped('Variadics are not supported in PHP versions prior to 5.6');
         }
 
@@ -703,8 +701,7 @@ class Phake_ClassGenerator_MockClassTest extends TestCase
 
     public function testMockingVariadics()
     {
-        if (version_compare(phpversion(), '5.6.0') < 0)
-        {
+        if (version_compare(phpversion(), '5.6.0') < 0) {
             $this->markTestSkipped('Variadics are not supported in PHP versions prior to 5.6');
         }
 
@@ -717,8 +714,7 @@ class Phake_ClassGenerator_MockClassTest extends TestCase
 
     public function testStubbingScalarReturnHints()
     {
-        if (version_compare(phpversion(), '7.0.0RC1') < 0)
-        {
+        if (version_compare(phpversion(), '7.0.0RC1') < 0) {
             $this->markTestSkipped('Scalar type hints are not supported in PHP versions prior to 7.0');
         }
 
@@ -731,8 +727,7 @@ class Phake_ClassGenerator_MockClassTest extends TestCase
 
     public function testStubbingScalarReturnsWrongType()
     {
-        if (version_compare(phpversion(), '7.0.0RC1') < 0)
-        {
+        if (version_compare(phpversion(), '7.0.0RC1') < 0) {
             $this->markTestSkipped('Scalar type hints are not supported in PHP versions prior to 7.0');
         }
 
@@ -740,17 +735,12 @@ class Phake_ClassGenerator_MockClassTest extends TestCase
 
         Phake::when($mock)->scalarHints->thenReturn(array());
 
-        try
-        {
+        try {
             $this->assertEquals(array(), $mock->scalarHints(1, 1));
-        }
-        catch (TypeError $e)
-        {
+        } catch (TypeError $e) {
             Phake::verify($mock)->scalarHints(1, 1);
             return;
-        }
-        catch (Throwable $e)
-        {
+        } catch (Throwable $e) {
             $this->fail("Expected A Type Error, instead got " . get_class($e) . " {$e}");
         }
         $this->fail("Expected A Type Error, no error received");
@@ -758,8 +748,7 @@ class Phake_ClassGenerator_MockClassTest extends TestCase
 
     public function testDefaultStubChanged()
     {
-        if (version_compare(phpversion(), '7.0.0RC1') < 0)
-        {
+        if (version_compare(phpversion(), '7.0.0RC1') < 0) {
             $this->markTestSkipped('Scalar type hints are not supported in PHP versions prior to 7.0');
         }
 
@@ -772,8 +761,7 @@ class Phake_ClassGenerator_MockClassTest extends TestCase
 
     public function testVoidStubReturnsProperly()
     {
-        if (version_compare(phpversion(), '7.1.0') < 0)
-        {
+        if (version_compare(phpversion(), '7.1.0') < 0) {
             $this->markTestSkipped('Void type hints are not supported in PHP versions prior to 7.1');
         }
 
@@ -786,8 +774,7 @@ class Phake_ClassGenerator_MockClassTest extends TestCase
 
     public function testVoidStubThrowsException()
     {
-        if (version_compare(phpversion(), '7.1.0') < 0)
-        {
+        if (version_compare(phpversion(), '7.1.0') < 0) {
             $this->markTestSkipped('Void type hints are not supported in PHP versions prior to 7.1');
         }
 
@@ -796,21 +783,17 @@ class Phake_ClassGenerator_MockClassTest extends TestCase
         $expectedException = new Exception("Test Exception");
         Phake::when($mock)->voidMethod->thenThrow($expectedException);
 
-        try
-        {
+        try {
             $mock->voidMethod();
             $this->fail("The mocked void method did not throw an exception");
-        }
-        catch (Exception $actualException)
-        {
+        } catch (Exception $actualException) {
             $this->assertSame($expectedException, $actualException, "The same exception was not thrown");
         }
     }
 
     public function testVoidStubCanCallParent()
     {
-        if (version_compare(phpversion(), '7.1.0') < 0)
-        {
+        if (version_compare(phpversion(), '7.1.0') < 0) {
             $this->markTestSkipped('Void type hints are not supported in PHP versions prior to 7.1');
         }
 
@@ -825,8 +808,7 @@ class Phake_ClassGenerator_MockClassTest extends TestCase
 
     public function testStubbingNotNullableReturnHint()
     {
-        if (version_compare(phpversion(), '7.1.0') < 0)
-        {
+        if (version_compare(phpversion(), '7.1.0') < 0) {
             $this->markTestSkipped('Nullable return hints are not supported in PHP versions prior to 7.1');
         }
 
@@ -834,34 +816,26 @@ class Phake_ClassGenerator_MockClassTest extends TestCase
 
         Phake::when($mock)->objectReturn->thenReturn(null);
 
-        try
-        {
+        try {
             $mock->objectReturn();
             $this->fail('Expected TypeError');
+        } catch (TypeError $e) {
+            $this->assertTrue(true);
         }
-        catch (TypeError $e)
-        {
-            return;
-        }
-
     }
 
     public function testStubbingNullableReturnHints()
     {
-        if (version_compare(phpversion(), '7.1.0') < 0)
-        {
+        if (version_compare(phpversion(), '7.1.0') < 0) {
             $this->markTestSkipped('Nullable return hints are not supported in PHP versions prior to 7.1');
         }
 
         $mock = Phake::mock('PhakeTest_NullableTypes');
         Phake::when($mock)->objectReturn->thenReturn(null);
 
-        try
-        {
+        try {
             $this->assertSame(null, $mock->objectReturn());
-        }
-        catch (TypeError $e)
-        {
+        } catch (TypeError $e) {
             $this->fail('Expected stubbing objectReturn null');
         }
 
@@ -870,19 +844,15 @@ class Phake_ClassGenerator_MockClassTest extends TestCase
 
     public function testStubbingNullableParameterHints()
     {
-        if (version_compare(phpversion(), '7.1.0') < 0)
-        {
+        if (version_compare(phpversion(), '7.1.0') < 0) {
             $this->markTestSkipped('Nullable return hints are not supported in PHP versions prior to 7.1');
         }
 
         $mock = Phake::mock('PhakeTest_NullableTypes');
 
-        try
-        {
+        try {
             $mock->objectParameter(null);
-        }
-        catch (TypeError $e)
-        {
+        } catch (TypeError $e) {
             $this->fail('Expected stubbing objectParameter to accept null');
         }
 
@@ -891,24 +861,19 @@ class Phake_ClassGenerator_MockClassTest extends TestCase
 
     public function testStubbingNullableReturnWrongType()
     {
-        if (version_compare(phpversion(), '7.1.0') < 0)
-        {
+        if (version_compare(phpversion(), '7.1.0') < 0) {
             $this->markTestSkipped('Nullable return hints are not supported in PHP versions prior to 7.1');
         }
 
         $mock = Phake::mock('PhakeTest_NullableTypes');
         Phake::when($mock)->objectReturn->thenReturn(array());
 
-        try
-        {
+        try {
             $mock->objectReturn();
-        }
-        catch (TypeError $e)
-        {
+        } catch (TypeError $e) {
+            $this->assertTrue(true);
             return;
-        }
-        catch (Throwable $e)
-        {
+        } catch (Throwable $e) {
             $this->fail("Expected A Type Error, instead got " . get_class($e) . " {$e}");
         }
 
@@ -917,8 +882,7 @@ class Phake_ClassGenerator_MockClassTest extends TestCase
 
     public function testDefaultReturnType()
     {
-        if (version_compare(phpversion(), '7.1.0') < 0)
-        {
+        if (version_compare(phpversion(), '7.1.0') < 0) {
             $this->markTestSkipped('Nullable return hints are not supported in PHP versions prior to 7.1');
         }
 
@@ -926,4 +890,3 @@ class Phake_ClassGenerator_MockClassTest extends TestCase
         $this->assertTrue($mock->objectReturn() instanceof PhakeTest_A);
     }
 }
-


### PR DESCRIPTION
This fixes having mock annotations that use imports on a parent test not finding the class. Instead of just getting property names, it now returns the `ReflectionProperty` so that we can get more information from it (such as the declaring class). We also then don't need to create another `ReflectionProperty` to modify it.

Fixes: #273