### PR TITLE
Prepend test namespace for mocked classes defined under that namespace

### DIFF
--- a/src/Phake/Annotation/MockInitializer.php
+++ b/src/Phake/Annotation/MockInitializer.php
@@ -80,7 +80,7 @@ class Phake_Annotation_MockInitializer
 
                     if (array_key_exists($key, $useStatements)) {
                         $mockedClass = $useStatements[$key];
-                    } elseif ($this->definedUnderTestNamespace($mockedClass, $reflectionClass->getNamespaceName())) {
+                    } elseif ($reflectionClass->getNamespaceName() && $this->definedUnderTestNamespace($mockedClass, $reflectionClass->getNamespaceName())) {
                         $mockedClass = $reflectionClass->getNamespaceName() . '\\' . $mockedClass;
                     }
                 }

--- a/src/Phake/Annotation/MockInitializer.php
+++ b/src/Phake/Annotation/MockInitializer.php
@@ -80,6 +80,8 @@ class Phake_Annotation_MockInitializer
 
                     if (array_key_exists($key, $useStatements)) {
                         $mockedClass = $useStatements[$key];
+                    } elseif ($this->definedUnderTestNamespace($mockedClass, $reflectionClass->getNamespaceName())) {
+                        $mockedClass = $reflectionClass->getNamespaceName() . '\\' . $mockedClass;
                     }
                 }
             }
@@ -92,5 +94,10 @@ class Phake_Annotation_MockInitializer
     protected function useDoctrineParser()
     {
         return version_compare(PHP_VERSION, "5.3.3", ">=") && class_exists('Doctrine\Common\Annotations\PhpParser');
+    }
+
+    protected function definedUnderTestNamespace($mockedClass, $testNamespace)
+    {
+        return class_exists($testNamespace . '\\' . $mockedClass);
     }
 }

--- a/tests/Phake/Annotation/MockInitializerClassWithTestNamespaceTest.php
+++ b/tests/Phake/Annotation/MockInitializerClassWithTestNamespaceTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Phake - Mocking Framework
+ *
+ * Copyright (c) 2010, Mike Lively <mike.lively@sellingsource.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  *  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *  *  Neither the name of Mike Lively nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category   Testing
+ * @package    Phake
+ * @author     Mike Lively <m@digitalsandwich.com>
+ * @copyright  2010 Mike Lively <m@digitalsandwich.com>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.digitalsandwich.com/
+ */
+
+namespace Test;
+
+use Phake;
+use PHPUnit\Framework\TestCase;
+
+class TestUtility
+{
+
+}
+
+class Phake_Annotation_MockInitializerWithNamespaceTest extends TestCase
+{
+    /**
+     * @var TestUtility
+     * @Mock
+     */
+    private $testUtility;
+
+    public function setUp()
+    {
+        Phake::initAnnotations($this);
+    }
+
+    public function testClassSuccessfullyMocked()
+    {
+        $this->assertNotNull($this->testUtility);
+    }
+}


### PR DESCRIPTION
Fixes #275, if the class is not found in the list of `use` statements, it will check if the class exists under the defined namespace. If so, it will prepend the NS onto the mocked class so it can be imported properly.