### PR TITLE
ReflectionType::__toString() is deprecated in PHP 7.4

### DIFF
--- a/src/Phake/ClassGenerator/MockClass.php
+++ b/src/Phake/ClassGenerator/MockClass.php
@@ -486,7 +486,7 @@ class {$newClassName} {$extends}
         if (method_exists($method, 'hasReturnType') && $method->hasReturnType())
         {
             $returnType = $method->getReturnType();
-            $returnTypeName = (string)$returnType;
+            $returnTypeName = $returnType->getName();
 
             if ($returnTypeName == 'self')
             {
@@ -616,7 +616,7 @@ class {$newClassName} {$extends}
                 $type = $parameter->getClass()->getName() . ' ';
             } elseif (method_exists($parameter, 'hasType') && $parameter->hasType())
             {
-                $type = $parameter->getType() . ' ';
+                $type = $parameter->getType()->getName() . ' ';
             }
 
             if (method_exists($parameter, 'hasType') && $parameter->hasType() && $parameter->allowsNull()) {

--- a/src/Phake/Stubber/Answers/SmartDefaultAnswer.php
+++ b/src/Phake/Stubber/Answers/SmartDefaultAnswer.php
@@ -63,7 +63,7 @@ class Phake_Stubber_Answers_SmartDefaultAnswer implements Phake_Stubber_IAnswer
 
         if (method_exists($method, 'hasReturnType') && $method->hasReturnType())
         {
-            switch ((string)$method->getReturnType())
+            switch ($method->getReturnType()->getName())
             {
                 case 'int':
                     $defaultAnswer = 0;
@@ -84,9 +84,9 @@ class Phake_Stubber_Answers_SmartDefaultAnswer implements Phake_Stubber_IAnswer
                     $defaultAnswer = function () {};
                     break;
                 default:
-                    if (class_exists((string)$method->getReturnType()))
+                    if (class_exists($method->getReturnType()->getName()))
                     {
-                        $defaultAnswer = Phake::mock((string)$method->getReturnType());
+                        $defaultAnswer = Phake::mock($method->getReturnType()->getName());
                     }
                     break;
             }


### PR DESCRIPTION
PHPUnit throws deprecation errors when Phake uses this method in PHP 7.4

ErrorException: Function ReflectionType::__toString() is deprecated

This patch replaces the instances of (string)$returnType with $returnType->getName(); allowing Phake to work on PHP 7.4 without deprecation warnings/errors.

Resolves issue #279 