### PR TITLE
PHP 8.0 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,70 @@
 language: php
 
-dist: trusty
-
-php:
-  - 7.1
-  - 7.2
-  - 7.3
-
-env:
-  - PHPUNIT_VERSION=6.5.14
-  - PHPUNIT_VERSION=7.5
-  - PHPUNIT_VERSION=8.1
-  - PHPUNIT_VERSION=9.0
-
 
 script:
   - ./bin/phpunit --coverage-clover=build/logs/clover.xml
 
 matrix:
-  allow_failures:
-    - env: PHPUNIT_VERSION=8.1
-    - env: PHPUNIT_VERSION=9.0
-#  exclude:
-#    - php: 7.1
-#      env: PHPUNIT_VERSION=8.1
+  include:
+   - php: 7.1
+     env: PHPUNIT_VERSION=6.5.14
+     dist: trusty
+
+   - php: 7.1
+     env: PHPUNIT_VERSION=7.5
+     dist: trusty
+
+   - php: 7.2
+     env: PHPUNIT_VERSION=6.5.14
+     dist: trusty
+
+   - php: 7.2
+     env: PHPUNIT_VERSION=7.5
+     dist: trusty
+
+   - php: 7.2
+     env: PHPUNIT_VERSION=8.1
+     dist: trusty
+
+   - php: 7.3
+     env: PHPUNIT_VERSION=7.5
+     dist: trusty
+
+   - php: 7.3
+     env: PHPUNIT_VERSION=8.1
+     dist: trusty
+
+   - php: 7.3
+     env: PHPUNIT_VERSION=9.0
+     dist: trusty
+
+   - php: 7.3
+     env: PHPUNIT_VERSION=9.5
+     dist: xenial
+
+   - php: 7.4
+     env: PHPUNIT_VERSION=8.5
+     dist: xenial
+
+   - php: 7.4
+     env: PHPUNIT_VERSION=9.0
+     dist: xenial
+
+   - php: 7.4
+     env: PHPUNIT_VERSION=9.5
+     dist: xenial
+
+   - php: 8.0
+     env: PHPUNIT_VERSION=8.5
+     dist: xenial
+
+   - php: 8.0
+     env: PHPUNIT_VERSION=9.5
+     dist: xenial
 
 install:
-  - composer require --dev phpunit/phpunit:${PHPUNIT_VERSION}
-  - composer install --dev
+  - composer require --dev --ignore-platform-reqs phpunit/phpunit:${PHPUNIT_VERSION} 
+  - composer install --dev --ignore-platform-reqs
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7",
+        "php": ">=7.1",
         "sebastian/comparator": "^1.1|^2.0|^3.0|^4.0"
     },
     "require-dev": {

--- a/tests/Phake/Annotation/MockInitializerClassWithTestNamespaceTest.php
+++ b/tests/Phake/Annotation/MockInitializerClassWithTestNamespaceTest.php
@@ -61,7 +61,7 @@ class Phake_Annotation_MockInitializerWithNamespaceTest extends TestCase
      */
     private $testUtility;
 
-    public function setUp()
+    public function setUp(): void
     {
         Phake::initAnnotations($this);
     }

--- a/tests/Phake/Annotation/MockInitializerParentTestCase.php
+++ b/tests/Phake/Annotation/MockInitializerParentTestCase.php
@@ -54,7 +54,7 @@ abstract class Phake_Annotation_MockInitializerParentTestCase extends TestCase
      */
     protected $testMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         Phake::initAnnotations($this);
     }

--- a/tests/Phake/Annotation/MockInitializerTest.php
+++ b/tests/Phake/Annotation/MockInitializerTest.php
@@ -79,7 +79,7 @@ class Phake_Annotation_MockInitializerTest extends TestCase
      */
     private $shortNameMock2;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (version_compare(PHP_VERSION, '5.3', '<')) {
             $this->markTestSkipped('ReflectionProperty::setAccessible() is not available');
@@ -88,7 +88,7 @@ class Phake_Annotation_MockInitializerTest extends TestCase
         $this->initializer = new Phake_Annotation_MockInitializer();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->initializer    = null;
         $this->mock1          = $this->mock2 = null;

--- a/tests/Phake/Annotation/ReaderTest.php
+++ b/tests/Phake/Annotation/ReaderTest.php
@@ -64,13 +64,13 @@ class Phake_Annotation_ReaderTest extends TestCase
 
     private $emptyVar2;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $reflectionClass = new ReflectionClass($this);
         $this->reader    = new Phake_Annotation_Reader($reflectionClass);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->reader    = null;
         $this->emptyVar  = null;

--- a/tests/Phake/CallRecorder/CallInfoTest.php
+++ b/tests/Phake/CallRecorder/CallInfoTest.php
@@ -68,7 +68,7 @@ class Phake_CallRecorder_CallInfoTest extends TestCase
     /**
      * Sets up the test fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->call     = $this->getMockBuilder('Phake_CallRecorder_Call')
                                 ->disableOriginalConstructor()

--- a/tests/Phake/CallRecorder/CallTest.php
+++ b/tests/Phake/CallRecorder/CallTest.php
@@ -63,7 +63,7 @@ class Phake_CallRecorder_CallTest extends TestCase
 
     private $mock;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->mock = Phake::mock('Phake_IMock');
 

--- a/tests/Phake/CallRecorder/OrderVerifierTest.php
+++ b/tests/Phake/CallRecorder/OrderVerifierTest.php
@@ -57,7 +57,7 @@ class Phake_CallRecorder_OrderVerifierTest extends TestCase
     /**
      * Sets up the test fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->verifier = new Phake_CallRecorder_OrderVerifier();
     }

--- a/tests/Phake/CallRecorder/PositionTest.php
+++ b/tests/Phake/CallRecorder/PositionTest.php
@@ -57,7 +57,7 @@ class Phake_CallRecorder_PositionTest extends TestCase
     /**
      * Sets up the test fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->position = new Phake_CallRecorder_Position(10);
     }

--- a/tests/Phake/CallRecorder/RecorderTest.php
+++ b/tests/Phake/CallRecorder/RecorderTest.php
@@ -53,7 +53,7 @@ class Phake_CallRecorder_RecorderTest extends TestCase
 {
     private $mock;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->mock = $this->getMockBuilder('Phake_IMock')
                     ->getMock();

--- a/tests/Phake/CallRecorder/VerifierMode/AtLeastTest.php
+++ b/tests/Phake/CallRecorder/VerifierMode/AtLeastTest.php
@@ -51,7 +51,7 @@ class Phake_CallRecorder_VerifierMode_AtLeastTest extends TestCase
 {
     private $verifierModeAtLeast;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->verifierModeAtLeast = new Phake_CallRecorder_VerifierMode_AtLeast(1);
     }

--- a/tests/Phake/CallRecorder/VerifierMode/AtMostTest.php
+++ b/tests/Phake/CallRecorder/VerifierMode/AtMostTest.php
@@ -51,7 +51,7 @@ class Phake_CallRecorder_VerifierMode_AtMostTest extends TestCase
 {
     private $verifier;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->verifier = new Phake_CallRecorder_VerifierMode_AtMost(1);
     }

--- a/tests/Phake/CallRecorder/VerifierMode/TimesTest.php
+++ b/tests/Phake/CallRecorder/VerifierMode/TimesTest.php
@@ -51,7 +51,7 @@ class Phake_CallRecorder_VerifierMode_TimesTest extends TestCase
 {
     private $verifierModeTimes;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->verifierModeTimes = new Phake_CallRecorder_VerifierMode_Times(1);
     }

--- a/tests/Phake/CallRecorder/VerifierTest.php
+++ b/tests/Phake/CallRecorder/VerifierTest.php
@@ -79,7 +79,7 @@ class Phake_CallRecorder_VerifierTest extends TestCase
     /**
      * Sets up the verifier and its call recorder
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->obj        = Phake::mock('Phake_IMock');
 

--- a/tests/Phake/ClassGenerator/InvocationHandler/CallRecorderTest.php
+++ b/tests/Phake/ClassGenerator/InvocationHandler/CallRecorderTest.php
@@ -58,7 +58,7 @@ class Phake_ClassGenerator_InvocationHandler_CallRecorderTest extends TestCase
      */
     private $callRecorder;
 
-    public function setUp()
+    public function setUp(): void
     {
         Phake::initAnnotations($this);
         $this->handler    = new Phake_ClassGenerator_InvocationHandler_CallRecorder($this->callRecorder);

--- a/tests/Phake/ClassGenerator/InvocationHandler/FrozenObjectCheckTest.php
+++ b/tests/Phake/ClassGenerator/InvocationHandler/FrozenObjectCheckTest.php
@@ -60,7 +60,7 @@ class Phake_ClassGenerator_InvocationHandler_FrozenObjectCheckTest extends TestC
      */
     private $mockInfo;
 
-    public function setUp()
+    public function setUp(): void
     {
         Phake::setClient(Phake::CLIENT_PHPUNIT7);
         Phake::initAnnotations($this);

--- a/tests/Phake/ClassGenerator/InvocationHandler/MagicCallRecorderTest.php
+++ b/tests/Phake/ClassGenerator/InvocationHandler/MagicCallRecorderTest.php
@@ -57,7 +57,7 @@ class Phake_ClassGenerator_InvocationHandler_MagicCallRecorderTest extends TestC
      */
     private $callRecorder;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->callRecorder = Phake::mock('Phake_CallRecorder_Recorder');
         $this->handler = new Phake_ClassGenerator_InvocationHandler_MagicCallRecorder($this->callRecorder);

--- a/tests/Phake/ClassGenerator/InvocationHandler/StubCallerTest.php
+++ b/tests/Phake/ClassGenerator/InvocationHandler/StubCallerTest.php
@@ -72,7 +72,7 @@ class Phake_ClassGenerator_InvocationHandler_StubCallerTest extends TestCase
      */
     private $defaultAnswer;
 
-    public function setUp()
+    public function setUp(): void
     {
         Phake::initAnnotations($this);
         $this->mock          = $this->getMockBuilder('Phake_IMock')->getMock();

--- a/tests/Phake/ClassGenerator/MockClassTest.php
+++ b/tests/Phake/ClassGenerator/MockClassTest.php
@@ -60,7 +60,7 @@ class Phake_ClassGenerator_MockClassTest extends TestCase
      */
     private $infoRegistry;
 
-    public function setUp()
+    public function setUp(): void
     {
         Phake::initAnnotations($this);
         $this->classGen = new Phake_ClassGenerator_MockClass();

--- a/tests/Phake/Client/DefaultTest.php
+++ b/tests/Phake/Client/DefaultTest.php
@@ -49,7 +49,7 @@ class Phake_Client_DefaultTest extends TestCase
 {
     private $client;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->client = new Phake_Client_Default();
     }

--- a/tests/Phake/Client/PHPUnitTest.php
+++ b/tests/Phake/Client/PHPUnitTest.php
@@ -52,7 +52,7 @@ class Phake_Client_PHPUnitTest extends TestCase
 {
     private $client;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (version_compare(Version::id(), '6.0.0') >= 0) {
             $this->markTestSkipped('The tested class is not compatible with current version of PHPUnit.');

--- a/tests/Phake/Client/PHPUnitTest6.php
+++ b/tests/Phake/Client/PHPUnitTest6.php
@@ -52,7 +52,7 @@ class Phake_Client_PHPUnitTest6 extends TestCase
 {
     private $client;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (version_compare(Version::id(), '6.0.0') < 0) {
             $this->markTestSkipped('The tested class is not compatible with current version of PHPUnit.');

--- a/tests/Phake/Client/PHPUnitTest7.php
+++ b/tests/Phake/Client/PHPUnitTest7.php
@@ -52,7 +52,7 @@ class Phake_Client_PHPUnitTest6 extends TestCase
 {
     private $client;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (version_compare(Version::id(), '7.0.0') < 0) {
             $this->markTestSkipped('The tested class is not compatible with current version of PHPUnit.');

--- a/tests/Phake/FacadeTest.php
+++ b/tests/Phake/FacadeTest.php
@@ -70,7 +70,7 @@ class Phake_FacadeTest extends TestCase
     /**
      * Sets up the mock generator
      */
-    public function setup()
+    public function setUp(): void
     {
         Phake::initAnnotations($this);
         $this->mockGenerator = $this->getMockBuilder('Phake_ClassGenerator_MockClass')->getMock();

--- a/tests/Phake/Matchers/AbstractChainableArgumentMatcherTest.php
+++ b/tests/Phake/Matchers/AbstractChainableArgumentMatcherTest.php
@@ -57,7 +57,7 @@ class Phake_Matchers_AbstractChainableArgumentMatcherTest extends TestCase
      */
     private $nextMatcher;
 
-    public function setUp()
+    public function setUp(): void
     {
         Phake::initAnnotations($this);
 

--- a/tests/Phake/Matchers/AnyParametersTest.php
+++ b/tests/Phake/Matchers/AnyParametersTest.php
@@ -51,7 +51,7 @@ class Phake_Matchers_AnyParametersTest extends TestCase
      */
     private $matcher;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->matcher = new Phake_Matchers_AnyParameters();
     }

--- a/tests/Phake/Matchers/ArgumentCaptorTest.php
+++ b/tests/Phake/Matchers/ArgumentCaptorTest.php
@@ -62,7 +62,7 @@ class Phake_Matchers_ArgumentCaptorTest extends TestCase
     /**
      * Sets up the test fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->captor = new Phake_Matchers_ArgumentCaptor($this->refVariable);
     }

--- a/tests/Phake/Matchers/ChainedArgumentMatcherTest.php
+++ b/tests/Phake/Matchers/ChainedArgumentMatcherTest.php
@@ -63,7 +63,7 @@ class Phake_Matchers_ChainedArgumentMatcherTest extends TestCase
      */
     private $nextMatcher;
 
-    public function setUp()
+    public function setUp(): void
     {
         Phake::initAnnotations($this);
 

--- a/tests/Phake/Matchers/EqualsMatcherTest.php
+++ b/tests/Phake/Matchers/EqualsMatcherTest.php
@@ -57,7 +57,7 @@ class Phake_Matchers_EqualsMatcherTest extends TestCase
     /**
      * Sets up the test fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->matcher = new Phake_Matchers_EqualsMatcher('foo', \SebastianBergmann\Comparator\Factory::getInstance());
     }

--- a/tests/Phake/Matchers/FactoryTest.php
+++ b/tests/Phake/Matchers/FactoryTest.php
@@ -55,7 +55,7 @@ class Phake_Matchers_FactoryTest extends TestCase
     /**
      * Sets up the test fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->factory = new Phake_Matchers_Factory();
     }

--- a/tests/Phake/Matchers/HamcrestMatcherAdapterTest.php
+++ b/tests/Phake/Matchers/HamcrestMatcherAdapterTest.php
@@ -62,7 +62,7 @@ class Phake_Matchers_HamcrestMatcherAdapterTest extends TestCase
     /**
      * Sets up the test fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->matcher = $this->getMockBuilder('Hamcrest\BaseMatcher')->getMock();
         $this->matcher->expects($this->any())

--- a/tests/Phake/Matchers/IgnoreRemainingMatcherTest.php
+++ b/tests/Phake/Matchers/IgnoreRemainingMatcherTest.php
@@ -51,7 +51,7 @@ class Phake_Matchers_IgnoreRemainingMatcherTest extends TestCase
      */
     private $matcher;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->matcher = new Phake_Matchers_IgnoreRemainingMatcher();
     }

--- a/tests/Phake/Matchers/MethodMatcherTest.php
+++ b/tests/Phake/Matchers/MethodMatcherTest.php
@@ -62,7 +62,7 @@ class Phake_Matchers_MethodMatcherTest extends TestCase
      */
     private $arguments;
 
-    public function setUp()
+    public function setUp(): void
     {
         Phake::initAnnotations($this);
 

--- a/tests/Phake/Matchers/PHPUnit6ConstraintAdapterTest.php
+++ b/tests/Phake/Matchers/PHPUnit6ConstraintAdapterTest.php
@@ -63,7 +63,7 @@ class Phake_Matchers_PHPUnit6ConstraintAdapterTest extends TestCase
     /**
      * Sets up the test fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->constraint = $this->getMockBuilder(Constraint::class)->getMock();
         $this->adapter    = new Phake_Matchers_PHPUnit6ConstraintAdapter($this->constraint);

--- a/tests/Phake/Matchers/PHPUnit7ConstraintAdapterTest.php
+++ b/tests/Phake/Matchers/PHPUnit7ConstraintAdapterTest.php
@@ -63,7 +63,7 @@ class Phake_Matchers_PHPUnit7ConstraintAdapterTest extends TestCase
     /**
      * Sets up the test fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->constraint = $this->getMockBuilder(Constraint::class)->getMock();
         $this->adapter    = new Phake_Matchers_PHPUnit7ConstraintAdapter($this->constraint);

--- a/tests/Phake/Matchers/ReferenceSetterTest.php
+++ b/tests/Phake/Matchers/ReferenceSetterTest.php
@@ -57,7 +57,7 @@ class Phake_Matchers_ReferenceSetterTest extends TestCase
     /**
      * Sets up the test fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->setter = new Phake_Matchers_ReferenceSetter(42);
     }

--- a/tests/Phake/Matchers/SingleArgumentMatcherTest.php
+++ b/tests/Phake/Matchers/SingleArgumentMatcherTest.php
@@ -57,7 +57,7 @@ class Phake_Matchers_SingleArgumentMatcherTest extends TestCase
      */
     private $nextMatcher;
 
-    public function setUp()
+    public function setUp(): void
     {
         Phake::initAnnotations($this);
 

--- a/tests/Phake/Mock/FreezerTest.php
+++ b/tests/Phake/Mock/FreezerTest.php
@@ -58,7 +58,7 @@ class Phake_Mock_FreezerTest extends TestCase
      */
     private $mockInfo;
 
-    public function setUp()
+    public function setUp(): void
     {
         Phake::initAnnotations($this);
         $this->freezer    = new Phake_Mock_Freezer();

--- a/tests/Phake/Mock/InfoRegistryTest.php
+++ b/tests/Phake/Mock/InfoRegistryTest.php
@@ -33,7 +33,7 @@ class Phake_Mock_InfoRegistryTest extends TestCase
      */
     private $info3;
 
-    public function setUp()
+    public function setUp(): void
     {
         Phake::initAnnotations($this);
         $this->registry = new Phake_Mock_InfoRegistry();

--- a/tests/Phake/Mock/InfoTest.php
+++ b/tests/Phake/Mock/InfoTest.php
@@ -75,7 +75,7 @@ class Phake_Mock_InfoTest extends TestCase {
      */
     private $handlerChain;
 
-    public function setUp()
+    public function setUp(): void
     {
         Phake::initAnnotations($this);
         $this->info = $this->getSUT();

--- a/tests/Phake/PHPUnit/VerifierResultConstraingV3d6Test.php
+++ b/tests/Phake/PHPUnit/VerifierResultConstraingV3d6Test.php
@@ -51,7 +51,7 @@ class Phake_PHPUnit_VerifierResultConstraintV3d6Test extends TestCase
 {
     private $constraint;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (version_compare('3.6.0', Version::id()) != 1) {
             $this->markTestSkipped('The tested class is not compatible with current version of PHPUnit.');

--- a/tests/Phake/PHPUnit/VerifierResultConstraingV6Test.php
+++ b/tests/Phake/PHPUnit/VerifierResultConstraingV6Test.php
@@ -51,7 +51,7 @@ class Phake_PHPUnit_VerifierResultConstraingV6Test extends TestCase
 {
     private $constraint;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (version_compare('6.0.0', Version::id()) != 1) {
             $this->markTestSkipped('The tested class is not compatible with current version of PHPUnit.');

--- a/tests/Phake/PHPUnit/VerifierResultConstraingV7Test.php
+++ b/tests/Phake/PHPUnit/VerifierResultConstraingV7Test.php
@@ -51,7 +51,7 @@ class Phake_PHPUnit_VerifierResultConstraingV7Test extends TestCase
 {
     private $constraint;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (version_compare('6.0.0', Version::id()) != 1) {
             $this->markTestSkipped('The tested class is not compatible with current version of PHPUnit.');

--- a/tests/Phake/PHPUnit/VerifierResultConstraintTest.php
+++ b/tests/Phake/PHPUnit/VerifierResultConstraintTest.php
@@ -51,7 +51,7 @@ class Phake_PHPUnit_VerifierResultConstraintTest extends TestCase
 {
     private $constraint;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (version_compare('3.6.0', Version::id()) != 1 && version_compare('6.0.0', Version::id()) != 1) {
             $this->markTestSkipped('The tested class is not compatible with current version of PHPUnit.');

--- a/tests/Phake/Proxies/AnswerBinderProxyTest.php
+++ b/tests/Phake/Proxies/AnswerBinderProxyTest.php
@@ -64,7 +64,7 @@ class Phake_Proxies_AnswerBinderProxyTest extends TestCase
     /**
      * Sets up the test fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->binder = $this->getMockBuilder('Phake_Stubber_AnswerBinder')
                             ->disableOriginalConstructor()

--- a/tests/Phake/Proxies/AnswerCollectionProxyTest.php
+++ b/tests/Phake/Proxies/AnswerCollectionProxyTest.php
@@ -59,7 +59,7 @@ class Phake_Proxies_AnswerCollectionProxyTest extends TestCase
     /**
      * Sets up the test fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->container = Phake::mock('Phake_Stubber_AnswerCollection');
         $this->proxy     = new Phake_Proxies_AnswerCollectionProxy($this->container);

--- a/tests/Phake/Proxies/CallStubberProxyTest.php
+++ b/tests/Phake/Proxies/CallStubberProxyTest.php
@@ -64,7 +64,7 @@ class Phake_Proxies_CallStubberProxyTest extends TestCase
     /**
      * Sets up test fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->matcher1 = Phake::mock('Phake_Matchers_IChainableArgumentMatcher');
         $this->obj      = $this->getMockBuilder('Phake_IMock')->getMock();

--- a/tests/Phake/Proxies/CallVerifierProxyTest.php
+++ b/tests/Phake/Proxies/CallVerifierProxyTest.php
@@ -64,7 +64,7 @@ class Phake_Proxies_CallVerifierProxyTest extends TestCase
     /**
      * Sets up test fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->client     = new Phake_Client_Default();
         $this->obj        = new Phake_CallRecorder_Recorder();

--- a/tests/Phake/Proxies/StubberProxyTest.php
+++ b/tests/Phake/Proxies/StubberProxyTest.php
@@ -64,7 +64,7 @@ class Phake_Proxies_StubberProxyTest extends TestCase
     /**
      * Sets up test fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->stubbable = Phake::mock('Phake_IMock');
         $this->proxy     = new Phake_Proxies_StubberProxy($this->stubbable, new Phake_Matchers_Factory());

--- a/tests/Phake/Proxies/VerifierProxyTest.php
+++ b/tests/Phake/Proxies/VerifierProxyTest.php
@@ -71,7 +71,7 @@ class Phake_Proxies_VerifierProxyTest extends TestCase
      */
     private $matchedCalls;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->verifier = Phake::mock('Phake_CallRecorder_Verifier');
         $this->mode = Phake::mock('Phake_CallRecorder_IVerifierMode');

--- a/tests/Phake/String/ConverterTest.php
+++ b/tests/Phake/String/ConverterTest.php
@@ -59,7 +59,7 @@ class Phake_String_ConverterTest extends TestCase
     /**
      * Sets up the mock generator
      */
-    public function setup()
+    public function setUp(): void
     {
         $this->converter = new Phake_String_Converter();
     }

--- a/tests/Phake/Stubber/AnswerBinderTest.php
+++ b/tests/Phake/Stubber/AnswerBinderTest.php
@@ -69,7 +69,7 @@ class Phake_Stubber_AnswerBinderTest extends TestCase
     /**
      * Sets up the test fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         Phake::initAnnotations($this);
         $this->matcher    = $this->getMockBuilder('Phake_Matchers_MethodMatcher')

--- a/tests/Phake/Stubber/AnswerCollectionTest.php
+++ b/tests/Phake/Stubber/AnswerCollectionTest.php
@@ -56,7 +56,7 @@ class Phake_Stubber_AnswerCollectionTest extends TestCase
      */
     private $answer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->answer     = Phake::mock('Phake_Stubber_IAnswer');
         $this->collection = new Phake_Stubber_AnswerCollection($this->answer);

--- a/tests/Phake/Stubber/Answers/ExceptionAnswerTest.php
+++ b/tests/Phake/Stubber/Answers/ExceptionAnswerTest.php
@@ -62,7 +62,7 @@ class Phake_Stubber_Answers_ExceptionAnswerTest extends TestCase
     /**
      * Sets up the answer fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->exception = new RuntimeException();
         $this->answer    = new Phake_Stubber_Answers_ExceptionAnswer($this->exception);

--- a/tests/Phake/Stubber/Answers/ParentDelegateTest.php
+++ b/tests/Phake/Stubber/Answers/ParentDelegateTest.php
@@ -57,7 +57,7 @@ class Phake_Stubber_Answers_ParentDelegateTest extends TestCase
     /**
      * Sets up the test fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->delegate = new Phake_Stubber_Answers_ParentDelegate();
     }

--- a/tests/Phake/Stubber/Answers/SelfAnswerTest.php
+++ b/tests/Phake/Stubber/Answers/SelfAnswerTest.php
@@ -54,7 +54,7 @@ class Phake_Stubber_Answers_SelfAnswerTest extends TestCase
     /**
      * Sets up the answer fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->answer = new Phake_Stubber_Answers_SelfAnswer();
     }

--- a/tests/Phake/Stubber/Answers/SmartDefaultAnswerTest.php
+++ b/tests/Phake/Stubber/Answers/SmartDefaultAnswerTest.php
@@ -57,7 +57,7 @@ class Phake_Stubber_Answers_SmartDefaultAnswerTest extends TestCase
     /**
      * Sets up the test fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         if (version_compare(phpversion(), '7.0.0RC1') < 0)
         {

--- a/tests/Phake/Stubber/Answers/StaticAnswerTest.php
+++ b/tests/Phake/Stubber/Answers/StaticAnswerTest.php
@@ -59,7 +59,7 @@ class Phake_Stubber_Answers_StaticAnswerTest extends TestCase
     /**
      * Sets up the answer fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->answer = new Phake_Stubber_Answers_StaticAnswer(42);
     }

--- a/tests/Phake/Stubber/SelfBindingAnswerBinderTest.php
+++ b/tests/Phake/Stubber/SelfBindingAnswerBinderTest.php
@@ -57,7 +57,7 @@ class Phake_Stubber_SelfBindingAnswerBinderTest extends TestCase
     /**
      * Sets up the test fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->binder = new Phake_Stubber_SelfBindingAnswerBinder();
     }

--- a/tests/Phake/Stubber/StubMapperTest.php
+++ b/tests/Phake/Stubber/StubMapperTest.php
@@ -59,7 +59,7 @@ class Phake_Stubber_StubMapperTest extends TestCase
     /**
      * Sets up the test fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->mapper = new Phake_Stubber_StubMapper();
     }

--- a/tests/PhakeClientTest.php
+++ b/tests/PhakeClientTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Runner\Version;
 
 class PhakeClientTest extends TestCase
 {
-    protected function setup()
+    protected function setUp(): void
     {
         // unset the $client in Phake
         $refClass = new ReflectionClass('Phake');

--- a/tests/PhakeTest.php
+++ b/tests/PhakeTest.php
@@ -42,8 +42,8 @@
  * @link       http://www.digitalsandwich.com/
  */
 
-use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the behavior of the Phake class.
@@ -54,12 +54,12 @@ use PHPUnit\Framework\ExpectationFailedException;
  */
 class PhakeTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         Phake::setClient(Phake::CLIENT_PHPUNIT7);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Phake::resetStaticInfo();
         Phake::setClient(Phake::CLIENT_PHPUNIT7);


### PR DESCRIPTION
Resolves #289 

Avoid using ReflectionParameter isArray, isCallable & getClass
as these are depreciated.

Set minimum php version as 7.1 as ReflectionNamedType is available
as of this version

This was what was required to get Phake working with PHP8 working my project - Open to feedback