### PR TITLE
Add support for native annotations

### DIFF
--- a/src/Phake/Annotation/IReader.php
+++ b/src/Phake/Annotation/IReader.php
@@ -40,84 +40,15 @@ namespace Phake\Annotation;
  * @category   Testing
  * @package    Phake
  * @author     Mike Lively <m@digitalsandwich.com>
+ * @author     Pierrick Charron <pierrick@adoy.net>
  * @copyright  2010 Mike Lively <m@digitalsandwich.com>
  * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
  * @link       http://www.digitalsandwich.com/
  */
 
-/**
- * Allows reading annotations from various components
- */
-class Reader
+interface IReader
 {
-    /**
-     * @var \ReflectionClass
-     */
-    private $clazz;
+    public function getPropertiesWithMockAnnotation(\ReflectionClass $class): iterable;
 
-    /**
-     * @param \ReflectionClass $clazz
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function __construct(\ReflectionClass $clazz)
-    {
-        $this->clazz = $clazz;
-    }
-
-    /**
-     * Returns an associative array containing a property's annotations and their values.
-     *
-     * @param string $property
-     *
-     * @return array
-     */
-    public function getPropertyAnnotations($property)
-    {
-        $property = $this->clazz->getProperty($property);
-
-        return $this->readReflectionAnnotation($property);
-    }
-
-    /**
-     * Returns an array containing the names of all properties containing a particular annotation.
-     *
-     * @param string $annotation
-     *
-     * @return ReflectionProperty[]
-     */
-    public function getPropertiesWithAnnotation($annotation)
-    {
-        $properties = array();
-        foreach ($this->clazz->getProperties() as $property) {
-            $annotations = $this->getPropertyAnnotations($property->getName());
-
-            if (array_key_exists($annotation, $annotations)) {
-                $properties[] = $property;
-            }
-        }
-        return $properties;
-    }
-
-    /**
-     * Returns all annotations for the given reflection object.
-     *
-     * @internal
-     *
-     * @param mixed $reflVar - must be an object that has the 'getDocComment' method.
-     *
-     * @return array
-     */
-    public function readReflectionAnnotation($reflVar)
-    {
-        $comment = $reflVar->getDocComment();
-
-        $annotations = array();
-        foreach (explode("\n", $comment) as $line) {
-            if (preg_match('#^\s+\*\s*@(\w+)(?:\s+(.*))?\s*$#', $line, $matches)) {
-                $annotations[$matches[1]] = isset($matches[2]) ? $matches[2] : true;
-            }
-        }
-        return $annotations;
-    }
+    public function getMockType(\ReflectionProperty $property): ?string;
 }

--- a/src/Phake/Annotation/LegacyReader.php
+++ b/src/Phake/Annotation/LegacyReader.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Phake\Annotation;
+
+use ReflectionClass;
+use ReflectionProperty;
+
+/*
+ * Phake - Mocking Framework
+ *
+ * Copyright (c) 2010-2021, Mike Lively <mike.lively@sellingsource.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  *  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *  *  Neither the name of Mike Lively nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category   Testing
+ * @package    Phake
+ * @author     Mike Lively <m@digitalsandwich.com>
+ * @copyright  2010 Mike Lively <m@digitalsandwich.com>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.digitalsandwich.com/
+ */
+
+class LegacyReader implements IReader
+{
+    private const ANNOTATION_NAME = 'Mock';
+
+    public function getPropertiesWithMockAnnotation(ReflectionClass $class): iterable
+    {
+        $properties = [];
+        foreach ($class->getProperties() as $property) {
+            $annotations = $this->getPropertyAnnotations($property);
+
+            if (isset($annotations[self::ANNOTATION_NAME])) {
+                $properties[] = $property;
+            }
+        }
+
+        return $properties;
+    }
+
+    public function getMockType(ReflectionProperty $property): ?string
+    {
+        $mockedClass = null;
+        $annotations = $this->getPropertyAnnotations($property);
+
+		if ($annotations['Mock'] !== true) {
+			$mockedClass = $annotations['Mock'];
+		} elseif (isset($annotations['var'])) {
+			$mockedClass = $annotations['var'];
+		}
+
+		if ($mockedClass && substr($mockedClass, 0, 1) !== '\\' &&  $this->useDoctrineParser()) {
+			$parser = new \Doctrine\Common\Annotations\PhpParser();
+
+            $reflectionClass = $property->getDeclaringClass();
+            $useStatements   = $parser->parseClass($reflectionClass);
+            $key             = strtolower($mockedClass);
+
+            if (array_key_exists($key, $useStatements)) {
+                $mockedClass = $useStatements[$key];
+            } elseif ($reflectionClass->getNamespaceName() && $this->definedUnderTestNamespace($mockedClass, $reflectionClass->getNamespaceName())) {
+                $mockedClass = $reflectionClass->getNamespaceName() . '\\' . $mockedClass;
+            }
+		}
+
+        return $mockedClass;
+    }
+
+    /**
+     * Returns an associative array containing a property's annotations and their values.
+     *
+     * @param string $property
+     *
+     * @return array
+     */
+    private function getPropertyAnnotations(\ReflectionProperty $property)
+    {
+        $comment = $property->getDocComment();
+
+        $annotations = array();
+        foreach (explode("\n", $comment) as $line) {
+            if (preg_match('#^\s+\*\s*@(\w+)(?:\s+(.*))?\s*$#', $line, $matches)) {
+                $annotations[$matches[1]] = isset($matches[2]) ? $matches[2] : true;
+            }
+        }
+        return $annotations;
+    }
+
+    private function useDoctrineParser(): bool
+    {
+        return class_exists('Doctrine\Common\Annotations\PhpParser');
+    }
+
+    private function definedUnderTestNamespace($mockedClass, $testNamespace): bool
+    {
+        return class_exists($testNamespace . '\\' . $mockedClass);
+    }
+}

--- a/src/Phake/Annotation/MockInitializer.php
+++ b/src/Phake/Annotation/MockInitializer.php
@@ -66,12 +66,21 @@ class MockInitializer
         $properties = $reader->getPropertiesWithAnnotation('Mock');
 
         foreach ($properties as $property) {
-            $annotations = $reader->readReflectionAnnotation($property);
+            $mockedClass = null;
+            if (method_exists($property, 'hasType') && $property->hasType()) {
+                $type = $property->getType();
+                if ($type instanceof \ReflectionNamedType) {
+                    $mockedClass = $type->getName();
+                }
+            }
+            if (null === $mockedClass) {
+                $annotations = $reader->readReflectionAnnotation($property);
 
-            if ($annotations['Mock'] !== true) {
-                $mockedClass = $annotations['Mock'];
-            } else {
-                $mockedClass = $annotations['var'];
+                if ($annotations['Mock'] !== true) {
+                    $mockedClass = $annotations['Mock'];
+                } else {
+                    $mockedClass = $annotations['var'];
+                }
             }
 
             if (isset($parser)) {
@@ -95,7 +104,7 @@ class MockInitializer
 
     protected function useDoctrineParser()
     {
-        return version_compare(PHP_VERSION, "5.3.3", ">=") && class_exists('Doctrine\Common\Annotations\PhpParser');
+        return class_exists('Doctrine\Common\Annotations\PhpParser');
     }
 
     protected function definedUnderTestNamespace($mockedClass, $testNamespace)

--- a/tests/Phake/Annotation/MockInitializerTypedPropertiesTest.php
+++ b/tests/Phake/Annotation/MockInitializerTypedPropertiesTest.php
@@ -1,0 +1,83 @@
+<?php
+
+if (version_compare(PHP_VERSION, '7.4.0', '>=')) {
+    $fp = fopen(__FILE__, 'r');
+    fseek($fp, __COMPILER_HALT_OFFSET__);
+    eval(stream_get_contents($fp));
+
+}
+
+__halt_compiler();
+
+namespace Phake\Annotation;
+
+/*
+ * Phake - Mocking Framework
+ *
+ * Copyright (c) 2010-2021, Mike Lively <mike.lively@sellingsource.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  *  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *  *  Neither the name of Mike Lively nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category   Testing
+ * @package    Phake
+ * @author     Mike Lively <m@digitalsandwich.com>
+ * @copyright  2010 Mike Lively <m@digitalsandwich.com>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.digitalsandwich.com/
+ */
+
+use PHPUnit\Framework\TestCase;
+use PhakeTest\AnotherNamespacedClass;
+
+/**
+ * @ann1 Test Annotation
+ * @ann2
+ */
+class MockInitializerTypesPropertiesTest extends TestCase
+{
+    /**
+     * @Mock
+     */
+    private \stdClass $mock;
+
+    protected function setUp(): void
+    {
+        $this->initializer = new MockInitializer();
+    }
+
+    public function testInitialize()
+    {
+        $this->initializer->initialize($this);
+
+        $this->assertInstanceOf(\stdClass::class, $this->mock);
+    }
+}
+

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -51,6 +51,7 @@ $loader->add('PhakeTest', __DIR__);
 require dirname(__DIR__) . '/vendor/hamcrest/hamcrest-php/hamcrest/Hamcrest.php';
 
 Phake::setClient(Phake::CLIENT_PHPUNIT8);
+Phake\Annotation\MockInitializer::setDefaultReader(new Phake\Annotation\LegacyReader());
 
 $cacheDir = getenv('PHAKE_CACHEDIR');
 if (!empty($cacheDir)) {


### PR DESCRIPTION
### Add support for typehint with `@Mock`

Example
```php
class Foo {
   /** @Mock */
   private stdClass $foo;
}
```

### Add support for native annotations

This commit introduce a new `Phake\Annotation\IReader` interface.
There are two implementations of this class :

`Phake\Annotation\LegacyReader` (default for php7)

This is the Phake 3.X way to do with the @Mock and @var annotations in the comments.

`Phake\Annotation\NativeReader` (default for php8)

This is the new way to do it. You need to add a `Phake\Mock` native attribute to your property.

```php
class Foo {
   #[Phake\Mock]
   private stdClass $mock;

   #[Phake\Mock(stdClass::class)]
   private $mock1;
   
   #[Phake\Mock(class: stdClass::class)]
   private $mock2
}
```

If you're using PHP8 but still want to load the old way you can use
```
Phake\Annotation\MockInitializer::setDefaultReader(
	new Phake\Annotation\LegacyReader()
);
```